### PR TITLE
Handle empty Gemini responses in art challenge verification

### DIFF
--- a/models/art_challenge_manager.py
+++ b/models/art_challenge_manager.py
@@ -448,7 +448,12 @@ Respond with ONLY the item name/description in lowercase, 2-6 words maximum. Not
                 )
             )
             
-            item = response.text.strip().lower()
+            response_text = (response.text or "").strip()
+            if not response_text:
+                logger.warning("Gemini returned empty edit item response")
+                return None
+
+            item = response_text.lower()
             # Clean up the response
             if item.startswith("- "):
                 item = item[2:]
@@ -630,7 +635,16 @@ Please verify if this submission includes all the required elements.
             )
             
             # Parse the response
-            response_text = response.text.strip()
+            response_text = (response.text or "").strip()
+            if not response_text:
+                logger.warning("Gemini returned empty verification response")
+                return {
+                    "verified": False,
+                    "confidence": 0,
+                    "reasoning": "AI verification returned an empty response",
+                    "matched_elements": [],
+                    "missing_elements": []
+                }
             
             # Try to extract JSON from the response
             try:


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when the Gemini API returns empty or null text for edit-item generation and submission verification.

### Description
- Added guards around `response.text` in `models/art_challenge_manager.py` to normalize to `response_text` and handle empty results when calling the Gemini `generate_content` responses.
- When generating edit items, log a warning and return `None` if the AI returned no text to avoid downstream crashes while processing `item`.
- When verifying submissions in `verify_submission`, log a warning and return a structured failure dictionary (with `verified: False` and `confidence: 0`) if the AI verification response is empty instead of proceeding to JSON parsing.
- Minor cleanup to use the normalized `response_text` variable in subsequent parsing and JSON extraction logic.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d17b058f0832cbb9354e847550bc5)