### PR TITLE
Guard empty Gemini responses for edit items, verification, and winner selection

### DIFF
--- a/models/art_challenge_manager.py
+++ b/models/art_challenge_manager.py
@@ -448,7 +448,12 @@ Respond with ONLY the item name/description in lowercase, 2-6 words maximum. Not
                 )
             )
             
-            item = response.text.strip().lower()
+            response_text = (response.text or "").strip()
+            if not response_text:
+                logger.warning("Gemini returned empty edit item response")
+                return None
+
+            item = response_text.lower()
             # Clean up the response
             if item.startswith("- "):
                 item = item[2:]
@@ -630,7 +635,16 @@ Please verify if this submission includes all the required elements.
             )
             
             # Parse the response
-            response_text = response.text.strip()
+            response_text = (response.text or "").strip()
+            if not response_text:
+                logger.warning("Gemini returned empty verification response")
+                return {
+                    "verified": False,
+                    "confidence": 0,
+                    "reasoning": "AI verification returned an empty response",
+                    "matched_elements": [],
+                    "missing_elements": []
+                }
             
             # Try to extract JSON from the response
             try:
@@ -1165,7 +1179,14 @@ The submissions are numbered 0 to {len(submission_data) - 1}."""
                 )
             )
             
-            response_text = response.text.strip()
+            response_text = (response.text or "").strip()
+            if not response_text:
+                logger.warning("Gemini returned empty winner selection response")
+                return {
+                    "user_id": submission_data[0]["user_id"],
+                    "image_url": submission_data[0]["image_url"],
+                    "reasoning": "Selected as winner! (AI returned no response)"
+                }
             
             # Parse the response
             try:

--- a/models/art_challenge_manager.py
+++ b/models/art_challenge_manager.py
@@ -448,7 +448,7 @@ Respond with ONLY the item name/description in lowercase, 2-6 words maximum. Not
                 )
             )
             
-            response_text = (response.text or "").strip()
+            response_text = (getattr(response, "text", None) or "").strip()
             if not response_text:
                 logger.warning("Gemini returned empty edit item response")
                 return None
@@ -635,7 +635,7 @@ Please verify if this submission includes all the required elements.
             )
             
             # Parse the response
-            response_text = (response.text or "").strip()
+            response_text = (getattr(response, "text", None) or "").strip()
             if not response_text:
                 logger.warning("Gemini returned empty verification response")
                 return {
@@ -1179,7 +1179,7 @@ The submissions are numbered 0 to {len(submission_data) - 1}."""
                 )
             )
             
-            response_text = (response.text or "").strip()
+            response_text = (getattr(response, "text", None) or "").strip()
             if not response_text:
                 logger.warning("Gemini returned empty winner selection response")
                 return {


### PR DESCRIPTION
### Motivation

- Prevent runtime errors when `response.text` from the Gemini `generate_content` call is `None` or empty and avoid downstream crashes or JSON parsing errors.
- Provide clear logging and sensible fallbacks instead of propagating `NoneType` errors.

### Description

- Normalize Gemini responses by using `response_text = (response.text or "").strip()` before processing the text in edit-item generation, verification, and winner-selection paths.
- In edit-item generation, log a warning and return `None` if the AI returned no text (`response_text` empty) to avoid processing a non-existent item.
- In verification, log a warning and return a structured failure dictionary with `verified: False`, `confidence: 0`, and empty element lists if the AI returned no text, avoiding JSON parsing on empty input.
- In winner selection, log a warning and fall back to returning the first submission (with a reasoning note) if the AI returned no text, preventing `NoneType` errors during parsing.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d17b058f0832cbb9354e847550bc5)