### PR TITLE
Moderate Discord invite links outside self-promo thread

### DIFF
--- a/config.py
+++ b/config.py
@@ -80,6 +80,9 @@ class Config:
     # Ask and complain to staff channel
     ASK_COMPLAIN_STAFF_CHANNEL_ID = 1426179557299453972  # Ask and complain to staff forum channel
     STAFF_ROLE_ID = 1372477845997359244  # Staff role to ping for all threads
+
+    # Self-promotion moderation
+    SELF_PROMO_WHITELIST_THREAD_ID = 1345520586012754001  # Thread where Discord invite links are allowed
     
     # Staff member IDs for specific pings
     STAFF_MEMBERS = {

--- a/controllers/events.py
+++ b/controllers/events.py
@@ -11,6 +11,7 @@ from models.user_safety_monitor import UserSafetyMonitor
 import logging
 import asyncio
 import random
+import re
 from datetime import datetime, timedelta
 from typing import List, Optional
 
@@ -22,6 +23,10 @@ TRENDING_POST_MIN_LIKES = 7  # Minimum likes for "Trending Creator" quest
 VIRAL_IMAGE_MIN_LIKES = 15  # Minimum likes for "viral_image" quest
 AI_MODERATION_TIMEOUT_THRESHOLD = 0.85  # 85% confidence required for auto-timeout
 AI_MODERATION_TIMEOUT_DURATION = timedelta(minutes=5)
+DISCORD_INVITE_REGEX = re.compile(
+    r"https?://(?:www\.)?(?:discord\.gg|discord(?:app)?\.com/invite)/[A-Za-z0-9-]+",
+    re.IGNORECASE
+)
 
 class EventsController:
     """Controller for handling Discord events"""
@@ -441,6 +446,9 @@ class EventsController:
         if not message.guild or message.guild.id != Config.GUILD_ID:
             return
 
+        if await self._handle_discord_invite_link(message):
+            return
+
         await self.user_safety_monitor.handle_message(message)
         
         # Check for positive Ino mentions first (reward good behavior!)
@@ -557,6 +565,40 @@ class EventsController:
             
             # Penalize InoRep for text spamming in image channels
             await self._apply_text_spam_inorep_penalty(message)
+
+    async def _handle_discord_invite_link(self, message: discord.Message) -> bool:
+        """Remove Discord invite links outside the self-promotion thread and DM the user."""
+        if message.channel.id == Config.SELF_PROMO_WHITELIST_THREAD_ID:
+            return False
+
+        if not DISCORD_INVITE_REGEX.search(message.content or ""):
+            return False
+
+        try:
+            await message.delete()
+            logger.info(
+                f"Removed Discord invite link from {message.author.display_name} in channel {message.channel.id}"
+            )
+        except discord.Forbidden:
+            logger.warning("Missing permission to delete Discord invite link message")
+            return False
+        except discord.NotFound:
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting Discord invite message: {e}")
+            return False
+
+        try:
+            await message.author.send(
+                "Hey! Please DM your Discord invite link directly to the person of interest. "
+                "We don't allow self-promotion links in the general server channels."
+            )
+        except discord.Forbidden:
+            logger.info(f"Could not DM {message.author.display_name} about invite link removal (DMs disabled)")
+        except Exception as e:
+            logger.error(f"Error sending Discord invite warning DM: {e}")
+
+        return True
     
     async def _check_for_chat_reminder(self, message: discord.Message):
         """Check if the last messages are text messages and send a chat reminder.


### PR DESCRIPTION
### Motivation
- Prevent public self-promotion via Discord invite links while allowing a dedicated whitelist thread for such posts. 
- Provide a single configuration entry to control the whitelisted thread so enforcement is centralized and configurable. 
- Fail gracefully when the bot lacks delete/DM permissions so moderation does not crash message processing. 

### Description
- Added `Config.SELF_PROMO_WHITELIST_THREAD_ID` to centralize the whitelisted thread ID for self-promotion. 
- Added `DISCORD_INVITE_REGEX` to detect `discord.gg`, `discord.com/invite`, and `discordapp.com/invite` invite URLs and implemented `_handle_discord_invite_link` to delete invite messages outside the whitelist and DM the author. 
- Integrated the invite check early in `EventsController._handle_message` so handled invite messages stop further processing and the rest of the message flow is skipped. 

### Testing
- Compiled the modified files with `python -m compileall controllers/events.py config.py` and the compilation completed successfully. 
- The new flow logs permission issues and DM failures instead of raising exceptions, and no runtime compile errors were produced during validation. 
- Regex covers `discord.gg/...` and both `discord.com/invite/...` and `discordapp.com/invite/...` URL forms and the handler returns early after enforcement to avoid duplicate processing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69979edf4898832c95243dc257b3688f)