### PR TITLE
Add scam image detection management

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 |---------|-------------|
 | **🔒 NSFWBAN System** | Persistent NSFW content bans with automatic role reapplication |
 | **👁️ Content Moderation** | AI-powered content moderation using OpenAI and Google NL APIs |
+| **🖼️ Scam Image Detection** | Mongo-backed SHA-256 and perceptual dHash detection for known scam images |
 | **📝 Audit Logging** | Complete logging of all moderation actions |
 | **🚫 Role Management** | Automatic role restriction enforcement |
 | **💬 DM Notifications** | Users receive detailed ban/unban notifications |
@@ -157,6 +158,12 @@ YOUTUBE_API_KEY=your_youtube_api_key         # YouTube Data API
 SERIKA_ART_KEY=your_serika_api_key           # Serika.art API access
 SERIKA_ART_URL_BASE=https://serika.art/api/v1
 
+# Scam Image Detection
+SCAM_IMAGE_DETECTION_ENABLED=true
+SCAM_IMAGE_DELETE_MATCHES=true
+SCAM_IMAGE_DHASH_DISTANCE=8
+SCAM_IMAGE_MAX_ATTACHMENT_BYTES=8388608
+
 # Patreon Integration
 PATREON_ROLE_ID=your_patreon_role_id         # Role for Patreon supporters
 ```
@@ -204,6 +211,16 @@ Enable these intents in the Discord Developer Portal:
 | `/nsfwunban <user>` | Remove NSFW ban from user | Moderators/Admins |
 | `/warn <user> <reason>` | Issue a warning to a user | Moderators/Admins |
 | `/purge <amount>` | Delete messages in bulk | Admins |
+| `/scamimage status` | View scam image detector status | Moderators/Admins |
+| `/scamimage scan <image>` | Scan an image without adding it | Moderators/Admins |
+| `/scamimage add <image> <label>` | Add an image signature | Moderators/Admins |
+| `/scamimage add_url` | Add an image signature from a URL modal | Moderators/Admins |
+| `/scamimage bulk_recent <label> [limit] [channel]` | Bulk-add recent channel images | Moderators/Admins |
+| `/scamimage list [query] [active_only]` | List scam image signatures | Moderators/Admins |
+| `/scamimage enable <sha256_prefix>` | Re-enable a signature | Moderators/Admins |
+| `/scamimage disable <sha256_prefix>` | Disable a signature | Moderators/Admins |
+| `/scamimage recent [limit]` | View recent detections and delete status | Moderators/Admins |
+| `/scamimage seed_defaults` | Import bundled known scam image signatures | Moderators/Admins |
 
 ### Owner Commands
 
@@ -251,6 +268,7 @@ Ino/
 │   ├── 📄 random_announcer.py          # AI-powered random announcements
 │   ├── 📄 role_manager.py              # Role management logic
 │   ├── 📄 moderation_manager.py        # Content moderation system
+│   ├── 📄 scam_image_manager.py        # Scam image signature detection
 │   ├── 📄 mod_offline_manager.py       # Offline moderation queue
 │   └── 📄 inorep_manager.py            # Reputation system
 │
@@ -258,6 +276,7 @@ Ino/
 │   ├── 📄 embeds.py                    # Discord embed templates
 │   ├── 📄 art_challenge_view.py        # Art challenge UI components
 │   ├── 📄 moderation_view.py           # Moderation UI components
+│   ├── 📄 scam_image_view.py           # Scam image management UI
 │   ├── 📄 forum_thread_view.py         # Forum thread UI
 │   ├── 📄 ask_staff_topic_view.py      # Staff request UI
 │   ├── 📄 combined_leaderboard_view.py # Leaderboard pagination
@@ -265,6 +284,7 @@ Ino/
 │
 ├── 📁 controllers/                     # Event handlers & command routing
 │   ├── 📄 commands.py                  # All bot commands (hybrid)
+│   ├── 📄 scam_image_controller.py     # Scam image commands and message scanner
 │   ├── 📄 events.py                    # Discord event handlers
 │   ├── 📄 scheduler.py                 # Scheduled tasks (best images, challenges)
 │   └── 📄 security.py                  # Command permission decorators

--- a/bot.py
+++ b/bot.py
@@ -71,12 +71,21 @@ class RikoBot(commands.Bot):
         self.twitch_monitor: Optional['TwitchMonitor'] = None
         self.random_announcer: Optional['RandomAnnouncer'] = None
         self.moderation_view_manager: Optional[object] = None
+        self.scam_image_manager: Optional[object] = None
+        self.scam_image_controller: Optional[object] = None
         
         # Initialize leaderboard manager first (required by other components)
         try:
             from models.mongo_leaderboard_manager import MongoLeaderboardManager
             self.leaderboard_manager = MongoLeaderboardManager()
             logger.info("✅ MongoDB leaderboard manager initialized successfully")
+            try:
+                from models.scam_image_manager import ScamImageManager
+                self.scam_image_manager = ScamImageManager(self.leaderboard_manager.db)
+                logger.info("✅ Scam image manager initialized successfully")
+            except Exception as e:
+                logger.error(f"❌ Failed to initialize scam image manager: {e}")
+                self.scam_image_manager = None
         except Exception as e:
             logger.error(f"❌ Failed to initialize MongoDB leaderboard manager: {e}")
             # Fallback to JSON-based leaderboard manager
@@ -134,6 +143,15 @@ class RikoBot(commands.Bot):
         self.events_controller = EventsController(self)
         self.commands_controller = CommandsController(self)
         self.scheduler_controller = SchedulerController(self)
+
+        if self.scam_image_manager:
+            try:
+                from controllers.scam_image_controller import ScamImageController
+                self.scam_image_controller = ScamImageController(self, self.scam_image_manager)
+                logger.info("✅ Scam image controller initialized successfully")
+            except Exception as e:
+                logger.error(f"❌ Failed to initialize scam image controller: {e}")
+                self.scam_image_controller = None
         
         # Initialize moderation view manager
         try:
@@ -170,6 +188,8 @@ class RikoBot(commands.Bot):
             self.events_controller.register_events()
         if self.commands_controller:
             self.commands_controller.register_commands()
+        if self.scam_image_controller:
+            self.scam_image_controller.register_commands()
         
         # Initialize quest manager after bot is ready
         if self.events_controller:

--- a/config.py
+++ b/config.py
@@ -31,6 +31,12 @@ class Config:
     GOOGLE_NL_API_KEY = os.getenv('GOOGLE_NL_API_KEY')  # For secondary moderation check
     TWITCH_CLIENT = os.getenv('TWITCH_CLIENT')
     TWITCH_SECRET = os.getenv('TWITCH_SECRET')
+
+    # Scam image detection
+    SCAM_IMAGE_DETECTION_ENABLED = os.getenv('SCAM_IMAGE_DETECTION_ENABLED', 'true').lower() == 'true'
+    SCAM_IMAGE_DELETE_MATCHES = os.getenv('SCAM_IMAGE_DELETE_MATCHES', 'true').lower() == 'true'
+    SCAM_IMAGE_DHASH_DISTANCE = get_int_env('SCAM_IMAGE_DHASH_DISTANCE', 8)
+    SCAM_IMAGE_MAX_ATTACHMENT_BYTES = get_int_env('SCAM_IMAGE_MAX_ATTACHMENT_BYTES', 8 * 1024 * 1024)
     
     # Moderation system default role IDs (can be configured per guild)
     DEFAULT_MODERATION_REVIEW_ROLE_ID = 1372477845997359244  # Seraphs role (default reviewers)

--- a/controllers/events.py
+++ b/controllers/events.py
@@ -523,6 +523,9 @@ class EventsController:
         if not message.guild or message.guild.id != Config.GUILD_ID:
             return
 
+        if await self._handle_scam_image_detection(message):
+            return
+
         if await self._handle_discord_invite_link(message):
             return
 
@@ -1575,6 +1578,17 @@ class EventsController:
             
         # Delete the image message from MongoDB if it exists
         await self.bot.leaderboard_manager.delete_image_message(str(message.id))
+
+    async def _handle_scam_image_detection(self, message: discord.Message) -> bool:
+        """Scan image attachments against known scam signatures."""
+        scam_image_controller = getattr(self.bot, 'scam_image_controller', None)
+        if not scam_image_controller:
+            return False
+        try:
+            return await scam_image_controller.scan_message(message)
+        except Exception as e:
+            logger.error(f"Error in scam image detection: {e}")
+            return False
     
     async def _handle_command_error(self, ctx: commands.Context, error: commands.CommandError):
         """Handle command errors"""

--- a/controllers/scam_image_controller.py
+++ b/controllers/scam_image_controller.py
@@ -1,0 +1,352 @@
+import logging
+from typing import Optional
+
+import aiohttp
+import discord
+from discord import app_commands
+
+from config import Config
+from views.scam_image_view import ScamImageAddUrlModal, ScamImageStatusView, signature_embed
+
+logger = logging.getLogger(__name__)
+
+
+class ScamImageController:
+    """Discord commands and message hooks for scam image detection."""
+
+    def __init__(self, bot, manager):
+        self.bot = bot
+        self.manager = manager
+        self.enabled = getattr(Config, "SCAM_IMAGE_DETECTION_ENABLED", True)
+        self.delete_matches = getattr(Config, "SCAM_IMAGE_DELETE_MATCHES", True)
+        self.dhash_distance = getattr(Config, "SCAM_IMAGE_DHASH_DISTANCE", 8)
+        self.max_attachment_bytes = getattr(Config, "SCAM_IMAGE_MAX_ATTACHMENT_BYTES", 8 * 1024 * 1024)
+
+    def register_commands(self):
+        group = app_commands.Group(
+            name="scamimage",
+            description="Manage scam image signatures and detections",
+        )
+
+        @group.command(name="status", description="Show scam image detector status")
+        async def status(interaction: discord.Interaction):
+            if not await self.can_manage_scam_images(interaction):
+                await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+                return
+
+            counts = self.manager.counts()
+            embed = discord.Embed(title="Scam Image Detection", color=discord.Color.blurple())
+            embed.add_field(name="Enabled", value=str(self.enabled), inline=True)
+            embed.add_field(name="Delete Matches", value=str(self.delete_matches), inline=True)
+            embed.add_field(name="dHash Distance", value=str(self.dhash_distance), inline=True)
+            embed.add_field(
+                name="Signatures",
+                value=f"{counts['active']} active / {counts['total']} total",
+                inline=True,
+            )
+            embed.add_field(name="Detections", value=str(counts["detections"]), inline=True)
+            await interaction.response.send_message(
+                embed=embed,
+                view=ScamImageStatusView(self),
+                ephemeral=True,
+            )
+
+        @group.command(name="scan", description="Scan an image without adding it")
+        @app_commands.describe(image="Image attachment to scan")
+        async def scan(interaction: discord.Interaction, image: discord.Attachment):
+            if not await self.can_manage_scam_images(interaction):
+                await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+                return
+
+            await interaction.response.defer(ephemeral=True)
+            body = await image.read(use_cached=True)
+            match = self.manager.find_match(image.filename, body, self.dhash_distance)
+            try:
+                signature = self.manager.build_signature(body, "scan only")
+            except Exception:
+                await interaction.followup.send("That attachment is not a readable image.", ephemeral=True)
+                return
+
+            embed = signature_embed("Scan Result", signature)
+            if match:
+                embed.color = discord.Color.red()
+                embed.add_field(
+                    name="Matched",
+                    value=f"`{match.kind}` {match.label}\n{match.detail}",
+                    inline=False,
+                )
+            else:
+                embed.color = discord.Color.orange()
+                embed.add_field(name="Matched", value="No", inline=False)
+            await interaction.followup.send(embed=embed, ephemeral=True)
+
+        @group.command(name="add", description="Add an image attachment to scam signatures")
+        @app_commands.describe(image="Image attachment to add", label="Short label for this signature")
+        async def add(interaction: discord.Interaction, image: discord.Attachment, label: str):
+            if not await self.can_manage_scam_images(interaction):
+                await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+                return
+
+            await interaction.response.defer(ephemeral=True)
+            if image.size > self.max_attachment_bytes:
+                await interaction.followup.send("That attachment is larger than the configured limit.", ephemeral=True)
+                return
+
+            body = await image.read(use_cached=True)
+            try:
+                signature = self.manager.build_signature(body, label)
+            except Exception:
+                await interaction.followup.send("That attachment is not a readable image.", ephemeral=True)
+                return
+
+            created, action = self.manager.add_signature(
+                signature,
+                source=f"discord attachment:{image.filename}",
+                added_by_id=interaction.user.id,
+                added_by_name=str(interaction.user),
+            )
+            embed = signature_embed(f"Signature {action.title()}", signature)
+            await interaction.followup.send(embed=embed, ephemeral=True)
+
+        @group.command(name="add_url", description="Open a modal to add an image by URL")
+        async def add_url(interaction: discord.Interaction):
+            if not await self.can_manage_scam_images(interaction):
+                await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+                return
+            await interaction.response.send_modal(ScamImageAddUrlModal(self))
+
+        @group.command(name="bulk_recent", description="Add image attachments from recent channel history")
+        @app_commands.describe(
+            label="Label to apply to added signatures",
+            limit="Messages to inspect, max 100",
+            channel="Channel to scan; defaults to current channel",
+        )
+        async def bulk_recent(
+            interaction: discord.Interaction,
+            label: str,
+            limit: app_commands.Range[int, 1, 100] = 25,
+            channel: Optional[discord.TextChannel] = None,
+        ):
+            if not await self.can_manage_scam_images(interaction):
+                await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+                return
+
+            await interaction.response.defer(ephemeral=True)
+            target = channel or interaction.channel
+            if not isinstance(target, discord.TextChannel):
+                await interaction.followup.send("Pick a text channel.", ephemeral=True)
+                return
+
+            added = 0
+            skipped = 0
+            async for message in target.history(limit=limit):
+                for attachment in message.attachments:
+                    if attachment.size > self.max_attachment_bytes:
+                        skipped += 1
+                        continue
+                    try:
+                        body = await attachment.read(use_cached=True)
+                        signature = self.manager.build_signature(body, label)
+                        self.manager.add_signature(
+                            signature,
+                            source=f"discord message:{message.id}/{attachment.filename}",
+                            added_by_id=interaction.user.id,
+                            added_by_name=str(interaction.user),
+                        )
+                        added += 1
+                    except Exception:
+                        skipped += 1
+
+            await interaction.followup.send(
+                f"Bulk add complete. Added/updated `{added}` signatures; skipped `{skipped}`.",
+                ephemeral=True,
+            )
+
+        @group.command(name="list", description="List scam image signatures")
+        async def list_signatures(
+            interaction: discord.Interaction,
+            query: Optional[str] = None,
+            active_only: bool = True,
+        ):
+            if not await self.can_manage_scam_images(interaction):
+                await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+                return
+            await self.send_signature_list(interaction, query=query, active_only=active_only)
+
+        @group.command(name="disable", description="Disable a scam image signature by SHA-256 prefix")
+        async def disable(interaction: discord.Interaction, sha256_prefix: str):
+            await self._set_signature_active(interaction, sha256_prefix, False)
+
+        @group.command(name="enable", description="Enable a scam image signature by SHA-256 prefix")
+        async def enable(interaction: discord.Interaction, sha256_prefix: str):
+            await self._set_signature_active(interaction, sha256_prefix, True)
+
+        @group.command(name="recent", description="Show recent scam image detections")
+        async def recent(interaction: discord.Interaction, limit: app_commands.Range[int, 1, 15] = 5):
+            if not await self.can_manage_scam_images(interaction):
+                await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+                return
+            await self.send_recent_detections(interaction, limit=limit)
+
+        @group.command(name="seed_defaults", description="Import bundled default scam image signatures")
+        async def seed_defaults(interaction: discord.Interaction):
+            if not await self.can_manage_scam_images(interaction):
+                await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+                return
+            await interaction.response.defer(ephemeral=True)
+            result = self.manager.seed_default_signatures()
+            await interaction.followup.send(
+                (
+                    "Default scam signatures imported. "
+                    f"Created `{result['created']}`, updated `{result['updated']}`, total `{result['total']}`."
+                ),
+                ephemeral=True,
+            )
+
+        self.bot.tree.add_command(group)
+
+    async def can_manage_scam_images(self, interaction: discord.Interaction) -> bool:
+        if not interaction.guild or not isinstance(interaction.user, discord.Member):
+            return False
+
+        if await self.bot.is_owner(interaction.user):
+            return True
+        if interaction.user.guild_permissions.administrator or interaction.user.guild_permissions.manage_guild:
+            return True
+
+        moderator_role_id = getattr(Config, "NSFWBAN_MODERATOR_ROLE_ID", None)
+        if moderator_role_id and discord.utils.get(interaction.user.roles, id=moderator_role_id):
+            return True
+        return False
+
+    async def scan_message(self, message: discord.Message) -> bool:
+        if not self.enabled or not message.attachments:
+            return False
+
+        for attachment in message.attachments:
+            if attachment.size > self.max_attachment_bytes:
+                continue
+            if not self.manager.is_supported_image(attachment.filename):
+                continue
+            try:
+                body = await attachment.read(use_cached=True)
+            except discord.HTTPException:
+                logger.warning(f"Could not read attachment {attachment.filename} from message {message.id}")
+                continue
+
+            match = self.manager.find_match(attachment.filename, body, self.dhash_distance)
+            if not match:
+                continue
+
+            detection_id = self.manager.record_detection(message, attachment, match)
+            logger.warning(
+                "Scam image match kind=%s label=%s user=%s channel=%s attachment=%s",
+                match.kind,
+                match.label,
+                message.author,
+                message.channel,
+                attachment.filename,
+            )
+
+            if self.delete_matches:
+                try:
+                    await message.delete()
+                    self.manager.update_detection_delete_result(detection_id, deleted=True, delete_error=None)
+                    return True
+                except discord.Forbidden:
+                    self.manager.update_detection_delete_result(
+                        detection_id,
+                        deleted=False,
+                        delete_error="missing Manage Messages permission",
+                    )
+                except discord.HTTPException as e:
+                    self.manager.update_detection_delete_result(
+                        detection_id,
+                        deleted=False,
+                        delete_error=str(e),
+                    )
+            return True
+        return False
+
+    async def add_url_from_modal(self, interaction: discord.Interaction, url: str, label: str):
+        if not await self.can_manage_scam_images(interaction):
+            await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url) as response:
+                    if response.status != 200:
+                        await interaction.followup.send(f"Could not fetch URL: HTTP {response.status}", ephemeral=True)
+                        return
+                    body = await response.read()
+        except Exception as e:
+            await interaction.followup.send(f"Could not fetch URL: `{e}`", ephemeral=True)
+            return
+
+        try:
+            signature = self.manager.build_signature(body, label)
+        except Exception:
+            await interaction.followup.send("That URL did not return a readable image.", ephemeral=True)
+            return
+
+        self.manager.add_signature(
+            signature,
+            source=url,
+            added_by_id=interaction.user.id,
+            added_by_name=str(interaction.user),
+        )
+        await interaction.followup.send(embed=signature_embed("Signature Added", signature), ephemeral=True)
+
+    async def send_signature_list(
+        self,
+        interaction: discord.Interaction,
+        query: Optional[str] = None,
+        active_only: bool = True,
+    ):
+        rows = self.manager.list_signatures(query=query, active_only=active_only, limit=10)
+        if not rows:
+            responder = interaction.response.send_message if not interaction.response.is_done() else interaction.followup.send
+            await responder("No scam image signatures found.", ephemeral=True)
+            return
+
+        embed = discord.Embed(title="Scam Image Signatures", color=discord.Color.blurple())
+        for row in rows:
+            status = "active" if row.get("active") else "disabled"
+            embed.add_field(
+                name=f"{row.get('label', 'unlabeled')} ({status})",
+                value=(
+                    f"`{row['sha256'][:16]}...`\n"
+                    f"{row.get('bytes', 0)} bytes, {row.get('width', 0)}x{row.get('height', 0)}, "
+                    f"dHash `{row.get('dhash', '')}`"
+                ),
+                inline=False,
+            )
+        responder = interaction.response.send_message if not interaction.response.is_done() else interaction.followup.send
+        await responder(embed=embed, ephemeral=True)
+
+    async def send_recent_detections(self, interaction: discord.Interaction, limit: int = 5):
+        rows = self.manager.recent_detections(limit=limit)
+        if not rows:
+            responder = interaction.response.send_message if not interaction.response.is_done() else interaction.followup.send
+            await responder("No scam image detections recorded yet.", ephemeral=True)
+            return
+
+        embed = discord.Embed(title="Recent Scam Image Detections", color=discord.Color.red())
+        for row in rows:
+            status = "deleted" if row.get("deleted") else f"not deleted ({row.get('delete_error') or 'unknown'})"
+            embed.add_field(
+                name=f"{row.get('match_label')} via {row.get('match_kind')}",
+                value=f"{row.get('user_name')} in #{row.get('channel_name')} - {status}",
+                inline=False,
+            )
+        responder = interaction.response.send_message if not interaction.response.is_done() else interaction.followup.send
+        await responder(embed=embed, ephemeral=True)
+
+    async def _set_signature_active(self, interaction: discord.Interaction, sha256_prefix: str, active: bool):
+        if not await self.can_manage_scam_images(interaction):
+            await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+            return
+        ok, message = self.manager.set_signature_active(sha256_prefix, active)
+        await interaction.response.send_message(("✅ " if ok else "❌ ") + message, ephemeral=True)

--- a/models/scam_image_manager.py
+++ b/models/scam_image_manager.py
@@ -1,0 +1,268 @@
+import hashlib
+import io
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image, UnidentifiedImageError
+from pymongo import ASCENDING, DESCENDING
+from pymongo.errors import DuplicateKeyError, PyMongoError
+
+logger = logging.getLogger(__name__)
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp"}
+
+
+@dataclass(frozen=True)
+class ScamImageSignature:
+    sha256: str
+    dhash: str
+    label: str
+    bytes: int
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class ScamImageMatch:
+    kind: str
+    label: str
+    detail: str
+    signature_sha256: Optional[str] = None
+    distance: Optional[int] = None
+
+
+class ScamImageManager:
+    """Mongo-backed scam image signature and detection manager."""
+
+    def __init__(self, db):
+        self.db = db
+        self.signatures_collection = self.db["scam_image_signatures"]
+        self.detections_collection = self.db["scam_image_detections"]
+        self._create_indexes()
+
+    def _create_indexes(self):
+        """Create additive indexes for scam image collections."""
+        try:
+            self.signatures_collection.create_index([("sha256", ASCENDING)], unique=True)
+            self.signatures_collection.create_index([("active", ASCENDING), ("created_at", DESCENDING)])
+            self.signatures_collection.create_index([("dhash", ASCENDING)])
+            self.signatures_collection.create_index([("label", ASCENDING)])
+
+            self.detections_collection.create_index([("message_id", ASCENDING), ("attachment_name", ASCENDING)])
+            self.detections_collection.create_index([("guild_id", ASCENDING), ("created_at", DESCENDING)])
+            self.detections_collection.create_index([("match_kind", ASCENDING)])
+            logger.info("Scam image indexes created successfully")
+        except PyMongoError as e:
+            logger.warning(f"Could not create scam image indexes: {e}")
+
+    @staticmethod
+    def is_supported_image(filename: str) -> bool:
+        return Path(filename).suffix.lower() in IMAGE_EXTENSIONS
+
+    @staticmethod
+    def dhash(image: Image.Image, hash_size: int = 8) -> int:
+        grayscale = image.convert("L").resize((hash_size + 1, hash_size), Image.Resampling.LANCZOS)
+        pixels = list(grayscale.getdata())
+        bits = []
+        for y in range(hash_size):
+            row = pixels[y * (hash_size + 1) : (y + 1) * (hash_size + 1)]
+            bits.extend("1" if row[x] > row[x + 1] else "0" for x in range(hash_size))
+        return int("".join(bits), 2)
+
+    @staticmethod
+    def hamming_distance(left_hex: str, right_hex: str) -> int:
+        return (int(left_hex, 16) ^ int(right_hex, 16)).bit_count()
+
+    def build_signature(self, body: bytes, label: str) -> ScamImageSignature:
+        image = Image.open(io.BytesIO(body))
+        image.load()
+        dhash_value = self.dhash(image)
+        return ScamImageSignature(
+            sha256=hashlib.sha256(body).hexdigest(),
+            dhash=f"{dhash_value:016x}",
+            label=label,
+            bytes=len(body),
+            width=image.width,
+            height=image.height,
+        )
+
+    def add_signature(
+        self,
+        signature: ScamImageSignature,
+        *,
+        source: str,
+        added_by_id: Optional[int] = None,
+        added_by_name: Optional[str] = None,
+    ) -> tuple[bool, str]:
+        now = datetime.utcnow()
+        doc = {
+            "sha256": signature.sha256,
+            "dhash": signature.dhash,
+            "label": signature.label,
+            "bytes": signature.bytes,
+            "width": signature.width,
+            "height": signature.height,
+            "source": source,
+            "active": True,
+            "added_by_id": str(added_by_id) if added_by_id else None,
+            "added_by_name": added_by_name,
+            "created_at": now,
+            "updated_at": now,
+        }
+        try:
+            self.signatures_collection.insert_one(doc)
+            return True, "created"
+        except DuplicateKeyError:
+            self.signatures_collection.update_one(
+                {"sha256": signature.sha256},
+                {
+                    "$set": {
+                        "label": signature.label,
+                        "dhash": signature.dhash,
+                        "bytes": signature.bytes,
+                        "width": signature.width,
+                        "height": signature.height,
+                        "source": source,
+                        "active": True,
+                        "updated_at": now,
+                    },
+                    "$setOnInsert": {"created_at": now},
+                },
+                upsert=True,
+            )
+            return False, "updated"
+
+    def seed_default_signatures(self, seed_path: Optional[Path] = None) -> dict:
+        """Import bundled default scam signatures idempotently."""
+        seed_path = seed_path or Path(__file__).with_name("scam_image_seed_data.json")
+        data = json.loads(seed_path.read_text(encoding="utf-8"))
+        created = 0
+        updated = 0
+
+        for item in data:
+            signature = ScamImageSignature(
+                sha256=item["sha256"].lower(),
+                dhash=item["dhash"].lower(),
+                label=item["label"],
+                bytes=int(item["bytes"]),
+                width=int(item["width"]),
+                height=int(item["height"]),
+            )
+            was_created, _ = self.add_signature(
+                signature,
+                source=item.get("source", str(seed_path)),
+            )
+            if was_created:
+                created += 1
+            else:
+                updated += 1
+
+        return {"created": created, "updated": updated, "total": len(data)}
+
+    def find_match(self, filename: str, body: bytes, dhash_distance: int = 8) -> Optional[ScamImageMatch]:
+        if not self.is_supported_image(filename):
+            return None
+
+        sha256 = hashlib.sha256(body).hexdigest()
+        exact = self.signatures_collection.find_one({"sha256": sha256, "active": True})
+        if exact:
+            return ScamImageMatch(
+                kind="sha256",
+                label=exact.get("label", "known scam image"),
+                detail=sha256,
+                signature_sha256=sha256,
+            )
+
+        try:
+            image = Image.open(io.BytesIO(body))
+            image.load()
+        except (UnidentifiedImageError, OSError):
+            return None
+
+        candidate = f"{self.dhash(image):016x}"
+        cursor = self.signatures_collection.find(
+            {"active": True, "dhash": {"$exists": True, "$ne": ""}},
+            {"sha256": 1, "dhash": 1, "label": 1},
+        )
+        for signature in cursor:
+            distance = self.hamming_distance(candidate, signature["dhash"])
+            if distance <= dhash_distance:
+                return ScamImageMatch(
+                    kind="dhash",
+                    label=signature.get("label", "visually similar scam image"),
+                    detail=f"{candidate} distance={distance}",
+                    signature_sha256=signature.get("sha256"),
+                    distance=distance,
+                )
+        return None
+
+    def record_detection(self, message, attachment, match: ScamImageMatch, *, deleted=False, delete_error=None):
+        doc = {
+            "guild_id": str(message.guild.id) if message.guild else None,
+            "guild_name": message.guild.name if message.guild else None,
+            "channel_id": str(message.channel.id),
+            "channel_name": getattr(message.channel, "name", str(message.channel)),
+            "message_id": str(message.id),
+            "user_id": str(message.author.id),
+            "user_name": str(message.author),
+            "attachment_name": attachment.filename,
+            "attachment_size": attachment.size,
+            "match_kind": match.kind,
+            "match_label": match.label,
+            "match_detail": match.detail,
+            "signature_sha256": match.signature_sha256,
+            "deleted": deleted,
+            "delete_error": delete_error,
+            "created_at": datetime.utcnow(),
+        }
+        result = self.detections_collection.insert_one(doc)
+        return result.inserted_id
+
+    def update_detection_delete_result(self, detection_id, *, deleted: bool, delete_error: Optional[str]):
+        self.detections_collection.update_one(
+            {"_id": detection_id},
+            {
+                "$set": {
+                    "deleted": deleted,
+                    "delete_error": delete_error,
+                    "updated_at": datetime.utcnow(),
+                }
+            },
+        )
+
+    def list_signatures(self, query: Optional[str] = None, active_only: bool = True, limit: int = 10):
+        filters = {}
+        if active_only:
+            filters["active"] = True
+        if query:
+            filters["$or"] = [
+                {"label": {"$regex": query, "$options": "i"}},
+                {"sha256": {"$regex": query, "$options": "i"}},
+            ]
+        return list(self.signatures_collection.find(filters).sort("created_at", DESCENDING).limit(limit))
+
+    def set_signature_active(self, sha256_prefix: str, active: bool) -> tuple[bool, str]:
+        matches = list(self.signatures_collection.find({"sha256": {"$regex": f"^{sha256_prefix.lower()}"}}))
+        if len(matches) == 0:
+            return False, "No signature matched that prefix."
+        if len(matches) > 1:
+            return False, f"That prefix matched {len(matches)} signatures. Use more hash characters."
+
+        self.signatures_collection.update_one(
+            {"_id": matches[0]["_id"]},
+            {"$set": {"active": active, "updated_at": datetime.utcnow()}},
+        )
+        return True, "Signature enabled." if active else "Signature disabled."
+
+    def recent_detections(self, limit: int = 5):
+        return list(self.detections_collection.find({}).sort("created_at", DESCENDING).limit(limit))
+
+    def counts(self) -> dict:
+        total = self.signatures_collection.count_documents({})
+        active = self.signatures_collection.count_documents({"active": True})
+        detections = self.detections_collection.count_documents({})
+        return {"total": total, "active": active, "detections": detections}

--- a/models/scam_image_seed_data.json
+++ b/models/scam_image_seed_data.json
@@ -1,0 +1,29 @@
+[
+  {
+    "sha256": "98202cbee51431dacb84cabfb18e0e4a4f47888fec8bd59f981d25450c4b0980",
+    "dhash": "600775618f4f3f3f",
+    "label": "mrbeast fake crypto casino tweet",
+    "bytes": 211974,
+    "width": 651,
+    "height": 1002,
+    "source": "default seed"
+  },
+  {
+    "sha256": "bd6eb98857741fabb3e50aeb45aa5e1f8e37a5cfe8998a8cefc543097d771723",
+    "dhash": "098f97b3b7923f37",
+    "label": "fake neobox bonus page",
+    "bytes": 142275,
+    "width": 624,
+    "height": 960,
+    "source": "default seed"
+  },
+  {
+    "sha256": "1b43e262b63230c1b5ae70008f2384e5e03468fddec60b96bd5826d944a1cd19",
+    "dhash": "7e7a783c1c2c1a32",
+    "label": "fake usdt withdrawal success",
+    "bytes": 253107,
+    "width": 1024,
+    "height": 1280,
+    "source": "default seed"
+  }
+]

--- a/tests/test_scam_image_manager_smoke.py
+++ b/tests/test_scam_image_manager_smoke.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models.scam_image_manager import ScamImageManager
+
+
+class FakeInsertResult:
+    def __init__(self, inserted_id):
+        self.inserted_id = inserted_id
+
+
+class FakeUpdateResult:
+    def __init__(self, modified_count=1):
+        self.modified_count = modified_count
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self.docs = list(docs)
+
+    def sort(self, *args, **kwargs):
+        return self
+
+    def limit(self, limit):
+        self.docs = self.docs[:limit]
+        return self
+
+    def __iter__(self):
+        return iter(self.docs)
+
+
+class FakeCollection:
+    def __init__(self):
+        self.docs = []
+        self.indexes = []
+
+    def create_index(self, *args, **kwargs):
+        self.indexes.append((args, kwargs))
+
+    def insert_one(self, doc):
+        if "sha256" in doc:
+            for existing in self.docs:
+                if existing.get("sha256") == doc["sha256"]:
+                    from pymongo.errors import DuplicateKeyError
+
+                    raise DuplicateKeyError("duplicate sha256")
+        stored = dict(doc)
+        stored["_id"] = len(self.docs) + 1
+        self.docs.append(stored)
+        return FakeInsertResult(stored["_id"])
+
+    def update_one(self, query, update, upsert=False):
+        for doc in self.docs:
+            if self._matches(doc, query):
+                doc.update(update.get("$set", {}))
+                return FakeUpdateResult()
+        if upsert:
+            doc = dict(query)
+            doc.update(update.get("$setOnInsert", {}))
+            doc.update(update.get("$set", {}))
+            return self.insert_one(doc)
+        return FakeUpdateResult(0)
+
+    def find_one(self, query, projection=None):
+        for doc in self.docs:
+            if self._matches(doc, query):
+                return dict(doc)
+        return None
+
+    def find(self, query=None, projection=None):
+        query = query or {}
+        return FakeCursor([dict(doc) for doc in self.docs if self._matches(doc, query)])
+
+    def count_documents(self, query):
+        return len([doc for doc in self.docs if self._matches(doc, query)])
+
+    def _matches(self, doc, query):
+        for key, expected in query.items():
+            if key == "$or":
+                return any(self._matches(doc, item) for item in expected)
+            actual = doc.get(key)
+            if isinstance(expected, dict):
+                if "$exists" in expected and (key in doc) != expected["$exists"]:
+                    return False
+                if "$ne" in expected and actual == expected["$ne"]:
+                    return False
+                if "$regex" in expected:
+                    import re
+
+                    flags = re.I if expected.get("$options") == "i" else 0
+                    if not re.search(expected["$regex"], str(actual or ""), flags):
+                        return False
+            elif actual != expected:
+                return False
+        return True
+
+
+class FakeDb:
+    def __init__(self):
+        self.collections = {}
+
+    def __getitem__(self, name):
+        self.collections.setdefault(name, FakeCollection())
+        return self.collections[name]
+
+
+def main():
+    manager = ScamImageManager(FakeDb())
+    sample = Path(r"C:\Users\SUBSECT\Downloads\image.jpeg")
+    body = sample.read_bytes()
+
+    signature = manager.build_signature(body, "fake neobox bonus page")
+    created, action = manager.add_signature(signature, source=str(sample), added_by_id=1, added_by_name="tester")
+    assert created is True
+    assert action == "created"
+
+    match = manager.find_match(sample.name, body)
+    assert match is not None
+    assert match.kind == "sha256"
+    assert match.label == "fake neobox bonus page"
+
+    rows = manager.list_signatures()
+    assert len(rows) == 1
+    assert rows[0]["sha256"] == signature.sha256
+
+    counts = manager.counts()
+    assert counts["total"] == 1
+    assert counts["active"] == 1
+
+    ok, message = manager.set_signature_active(signature.sha256[:12], False)
+    assert ok is True
+    assert "disabled" in message
+    assert manager.find_match(sample.name, body) is None
+
+    seeded = manager.seed_default_signatures()
+    assert seeded["total"] == 3
+    assert seeded["created"] >= 2
+
+    seeded_again = manager.seed_default_signatures()
+    assert seeded_again["total"] == 3
+    assert seeded_again["created"] == 0
+
+    print("scam image manager smoke test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/views/scam_image_view.py
+++ b/views/scam_image_view.py
@@ -1,0 +1,54 @@
+import discord
+
+
+def signature_embed(title: str, signature) -> discord.Embed:
+    embed = discord.Embed(title=title, color=discord.Color.green())
+    embed.add_field(name="Label", value=signature.label, inline=False)
+    embed.add_field(name="SHA-256", value=f"`{signature.sha256}`", inline=False)
+    embed.add_field(name="Size", value=f"{signature.bytes} bytes", inline=True)
+    embed.add_field(name="Dimensions", value=f"{signature.width}x{signature.height}", inline=True)
+    embed.add_field(name="dHash", value=f"`{signature.dhash}`", inline=True)
+    return embed
+
+
+class ScamImageStatusView(discord.ui.View):
+    def __init__(self, controller):
+        super().__init__(timeout=180)
+        self.controller = controller
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if await self.controller.can_manage_scam_images(interaction):
+            return True
+        await interaction.response.send_message(
+            "You need moderation permissions to manage scam image detection.",
+            ephemeral=True,
+        )
+        return False
+
+    @discord.ui.button(label="List", style=discord.ButtonStyle.secondary)
+    async def list_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.controller.send_signature_list(interaction)
+
+    @discord.ui.button(label="Recent", style=discord.ButtonStyle.secondary)
+    async def recent_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.controller.send_recent_detections(interaction)
+
+
+class ScamImageAddUrlModal(discord.ui.Modal, title="Add Scam Image URL"):
+    url = discord.ui.TextInput(
+        label="Image URL",
+        placeholder="https://cdn.discordapp.com/attachments/...",
+        max_length=2000,
+    )
+    label = discord.ui.TextInput(
+        label="Label",
+        placeholder="fake mrbeast crypto scam",
+        max_length=120,
+    )
+
+    def __init__(self, controller):
+        super().__init__(timeout=180)
+        self.controller = controller
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await self.controller.add_url_from_modal(interaction, str(self.url), str(self.label))


### PR DESCRIPTION
## Summary
- Add Mongo-backed scam image signatures and detection logging
- Add /scamimage slash command group for scan/add/bulk/list/enable/disable/recent/default seed workflows
- Hook image scanning into the existing message event flow using repo-native config, permissions, controllers, models, and views

## Testing
- python tests\test_scam_image_manager_smoke.py
- python -m py_compile bot.py config.py controllers\events.py controllers\scam_image_controller.py models\scam_image_manager.py views\scam_image_view.py tests\test_scam_image_manager_smoke.py
- Offline slash command registration check: scamimage 10

## Notes
- Uses existing MongoDB connection; no SQLite or second database
- Adds only new collections: scam_image_signatures and scam_image_detections
- Default signatures are imported manually via /scamimage seed_defaults, not auto-written at startup