### PR TITLE
Add scam image burst config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Enable these intents in the Discord Developer Portal:
 | `/scamimage scan <image>` | Scan an image without adding it | Moderators/Admins |
 | `/scamimage scan_recent [limit] [channel] [delete_matches]` | Scan recent channel images for known scam signatures | Moderators/Admins |
 | `/scamimage image_timeline [user] [minutes] [per_channel_limit] [include_ignored] [post_to_modlog]` | Inspect recent image timing across server channels without actions | Moderators/Admins |
+| `/scamimage burst_config [scan_enabled] [window_seconds] [delete_messages] [timeout_enabled] [timeout_seconds]` | View or update repeated-image burst actions | Moderators/Admins |
 | `/scamimage add <image> <label>` | Add an image signature | Moderators/Admins |
 | `/scamimage add_url` | Add an image signature from a URL modal | Moderators/Admins |
 | `/scamimage bulk_recent <label> [limit] [channel]` | Bulk-add recent channel images | Moderators/Admins |

--- a/README.md
+++ b/README.md
@@ -176,9 +176,10 @@ SCAM_IMAGE_CROSS_CHANNEL_WINDOW_SECONDS=15
 SCAM_IMAGE_CROSS_CHANNEL_ALERT_COOLDOWN_MINUTES=10
 SCAM_IMAGE_BURST_SCAN_ENABLED=true
 SCAM_IMAGE_BURST_WINDOW_SECONDS=70
-SCAM_IMAGE_BURST_DELETE_MESSAGES=false
+SCAM_IMAGE_BURST_DELETE_MESSAGES=true
 SCAM_IMAGE_BURST_TIMEOUT_ENABLED=true
-SCAM_IMAGE_BURST_TIMEOUT_SECONDS=60
+SCAM_IMAGE_BURST_TIMEOUT_SECONDS=180
+SCAM_IMAGE_BURST_DM_SECURITY_NOTICE=true
 
 # Patreon Integration
 PATREON_ROLE_ID=your_patreon_role_id         # Role for Patreon supporters
@@ -231,7 +232,7 @@ Enable these intents in the Discord Developer Portal:
 | `/scamimage scan <image>` | Scan an image without adding it | Moderators/Admins |
 | `/scamimage scan_recent [limit] [channel] [delete_matches]` | Scan recent channel images for known scam signatures | Moderators/Admins |
 | `/scamimage image_timeline [user] [minutes] [per_channel_limit] [include_ignored] [post_to_modlog]` | Inspect recent image timing across server channels without actions | Moderators/Admins |
-| `/scamimage burst_config [scan_enabled] [window_seconds] [delete_messages] [timeout_enabled] [timeout_seconds]` | View or update repeated-image burst actions | Moderators/Admins |
+| `/scamimage burst_config [scan_enabled] [window_seconds] [delete_messages] [timeout_enabled] [timeout_seconds] [dm_security_notice]` | View or update repeated-image burst actions | Moderators/Admins |
 | `/scamimage add <image> <label>` | Add an image signature | Moderators/Admins |
 | `/scamimage add_url` | Add an image signature from a URL modal | Moderators/Admins |
 | `/scamimage bulk_recent <label> [limit] [channel]` | Bulk-add recent channel images | Moderators/Admins |

--- a/config.py
+++ b/config.py
@@ -70,9 +70,10 @@ class Config:
         'SCAM_IMAGE_BURST_WINDOW_SECONDS',
         max(SCAM_IMAGE_CROSS_CHANNEL_WINDOW_SECONDS, 70)
     )
-    SCAM_IMAGE_BURST_DELETE_MESSAGES = os.getenv('SCAM_IMAGE_BURST_DELETE_MESSAGES', 'false').lower() == 'true'
+    SCAM_IMAGE_BURST_DELETE_MESSAGES = os.getenv('SCAM_IMAGE_BURST_DELETE_MESSAGES', 'true').lower() == 'true'
     SCAM_IMAGE_BURST_TIMEOUT_ENABLED = os.getenv('SCAM_IMAGE_BURST_TIMEOUT_ENABLED', 'true').lower() == 'true'
-    SCAM_IMAGE_BURST_TIMEOUT_SECONDS = get_int_env('SCAM_IMAGE_BURST_TIMEOUT_SECONDS', 60)
+    SCAM_IMAGE_BURST_TIMEOUT_SECONDS = get_int_env('SCAM_IMAGE_BURST_TIMEOUT_SECONDS', 180)
+    SCAM_IMAGE_BURST_DM_SECURITY_NOTICE = os.getenv('SCAM_IMAGE_BURST_DM_SECURITY_NOTICE', 'true').lower() == 'true'
     
     # Moderation system default role IDs (can be configured per guild)
     DEFAULT_MODERATION_REVIEW_ROLE_ID = 1372477845997359244  # Seraphs role (default reviewers)

--- a/controllers/scam_image_controller.py
+++ b/controllers/scam_image_controller.py
@@ -48,9 +48,10 @@ class ScamImageController:
         )
         self.image_burst_ignored_channel_ids = set(getattr(Config, "IMAGE_REACTION_CHANNELS", []))
         self.image_burst_ignored_channel_ids.update(getattr(Config, "ART_CHALLENGE_CHANNELS", []))
-        self.image_burst_delete_messages = getattr(Config, "SCAM_IMAGE_BURST_DELETE_MESSAGES", False)
+        self.image_burst_delete_messages = getattr(Config, "SCAM_IMAGE_BURST_DELETE_MESSAGES", True)
         self.image_burst_timeout_enabled = getattr(Config, "SCAM_IMAGE_BURST_TIMEOUT_ENABLED", True)
-        self.image_burst_timeout_seconds = getattr(Config, "SCAM_IMAGE_BURST_TIMEOUT_SECONDS", 60)
+        self.image_burst_timeout_seconds = getattr(Config, "SCAM_IMAGE_BURST_TIMEOUT_SECONDS", 180)
+        self.image_burst_dm_security_notice = getattr(Config, "SCAM_IMAGE_BURST_DM_SECURITY_NOTICE", True)
         self._image_burst_entries = []
         self._image_burst_confirmation_keys = set()
         self._image_burst_suppressed_until = {}
@@ -88,7 +89,8 @@ class ScamImageController:
                     f"window={self.image_burst_window_seconds}s, "
                     f"timeout={self.image_burst_timeout_enabled} "
                     f"({self.image_burst_timeout_seconds}s), "
-                    f"delete={self.image_burst_delete_messages}"
+                    f"delete={self.image_burst_delete_messages}, "
+                    f"dm={self.image_burst_dm_security_notice}"
                 ),
                 inline=False,
             )
@@ -351,6 +353,7 @@ class ScamImageController:
             delete_messages="Delete burst messages after an alert",
             timeout_enabled="Timeout users after a burst alert",
             timeout_seconds="Timeout duration in seconds",
+            dm_security_notice="DM account-security guidance after a burst alert",
         )
         async def burst_config(
             interaction: discord.Interaction,
@@ -359,6 +362,7 @@ class ScamImageController:
             delete_messages: Optional[bool] = None,
             timeout_enabled: Optional[bool] = None,
             timeout_seconds: Optional[app_commands.Range[int, 1, 86400]] = None,
+            dm_security_notice: Optional[bool] = None,
         ):
             if not await self.can_manage_scam_images(interaction):
                 await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
@@ -374,6 +378,7 @@ class ScamImageController:
                 "scam_image_burst_delete_messages": delete_messages,
                 "scam_image_burst_timeout_enabled": timeout_enabled,
                 "scam_image_burst_timeout_seconds": timeout_seconds,
+                "scam_image_burst_dm_security_notice": dm_security_notice,
             }
             changed = await self._save_image_burst_settings(interaction.guild, updates)
             embed = await self._image_burst_settings_embed(interaction.guild, changed=changed)
@@ -503,6 +508,14 @@ class ScamImageController:
             ),
             self.image_burst_timeout_seconds,
         )
+        self.image_burst_dm_security_notice = self._coerce_bool(
+            await moderation_manager.get_moderation_setting(
+                guild_id,
+                "scam_image_burst_dm_security_notice",
+                self.image_burst_dm_security_notice,
+            ),
+            self.image_burst_dm_security_notice,
+        )
         self._image_burst_settings_loaded_guilds.add(guild_id)
 
     async def _save_image_burst_settings(self, guild: discord.Guild, updates: dict) -> list[str]:
@@ -530,6 +543,7 @@ class ScamImageController:
         embed.add_field(name="Delete Messages", value=str(self.image_burst_delete_messages), inline=True)
         embed.add_field(name="Timeout Enabled", value=str(self.image_burst_timeout_enabled), inline=True)
         embed.add_field(name="Timeout Duration", value=f"{self.image_burst_timeout_seconds}s", inline=True)
+        embed.add_field(name="Security DM", value=str(self.image_burst_dm_security_notice), inline=True)
         if changed:
             labels = [name.replace("scam_image_burst_", "").replace("_", " ") for name in changed]
             embed.add_field(name="Updated", value=", ".join(labels), inline=False)
@@ -544,6 +558,7 @@ class ScamImageController:
             "scam_image_burst_delete_messages": "image_burst_delete_messages",
             "scam_image_burst_timeout_enabled": "image_burst_timeout_enabled",
             "scam_image_burst_timeout_seconds": "image_burst_timeout_seconds",
+            "scam_image_burst_dm_security_notice": "image_burst_dm_security_notice",
         }[setting_name]
 
     def _coerce_bool(self, value, default: bool) -> bool:
@@ -1058,6 +1073,40 @@ class ScamImageController:
                 results.append(f"Deleted {deleted} burst messages" if failed == 0 else f"Deleted {deleted} burst messages; failed {failed}")
         else:
             results.append("Message deletion disabled")
+
+        if self.image_burst_dm_security_notice:
+            try:
+                action_text = "temporarily restricted"
+                if not self.image_burst_timeout_enabled:
+                    action_text = "flagged for moderator review"
+                embed = discord.Embed(
+                    title="Account Security Notice",
+                    description=(
+                        f"Your account was {action_text} in **{message.guild.name}** because it posted "
+                        "the same or visually similar image across multiple channels in a short period."
+                    ),
+                    color=discord.Color.orange(),
+                    timestamp=datetime.utcnow(),
+                )
+                embed.add_field(
+                    name="If this was not you",
+                    value=(
+                        "Change your Discord password, enable 2FA, review authorized apps, "
+                        "and contact the server moderators after your account is secure."
+                    ),
+                    inline=False,
+                )
+                if self.image_burst_timeout_enabled:
+                    embed.add_field(name="Timeout", value=f"{self.image_burst_timeout_seconds}s", inline=True)
+                embed.set_footer(text="This is an automated anti-scam safety action.")
+                await message.author.send(embed=embed)
+                results.append("Security DM sent")
+            except discord.Forbidden:
+                results.append("Security DM skipped: DMs disabled")
+            except discord.HTTPException as e:
+                results.append(f"Security DM failed: {e}")
+        else:
+            results.append("Security DM disabled")
 
         return results
 

--- a/controllers/scam_image_controller.py
+++ b/controllers/scam_image_controller.py
@@ -54,6 +54,7 @@ class ScamImageController:
         self._image_burst_entries = []
         self._image_burst_confirmation_keys = set()
         self._image_burst_suppressed_until = {}
+        self._image_burst_settings_loaded_guilds = set()
         self.allowed_url_content_types = {"image/jpeg", "image/png", "image/webp", "image/bmp", "image/x-ms-bmp"}
 
     def register_commands(self):
@@ -68,6 +69,7 @@ class ScamImageController:
                 await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
                 return
 
+            await self._load_image_burst_settings(interaction.guild, force=True)
             counts = await asyncio.to_thread(self.manager.counts)
             embed = discord.Embed(title="Scam Image Detection", color=discord.Color.blurple())
             embed.add_field(name="Enabled", value=str(self.enabled), inline=True)
@@ -304,6 +306,7 @@ class ScamImageController:
                 return
 
             await interaction.response.defer(ephemeral=True)
+            await self._load_image_burst_settings(interaction.guild)
             report = await self._build_image_timeline_report(
                 interaction.guild,
                 requester=interaction.user,
@@ -340,6 +343,41 @@ class ScamImageController:
                 )
                 return
             await interaction.followup.send(embed=report, ephemeral=True)
+
+        @group.command(name="burst_config", description="View or update repeated-image burst actions")
+        @app_commands.describe(
+            scan_enabled="Enable repeated-image burst scanning",
+            window_seconds="Repeated-image burst window in seconds",
+            delete_messages="Delete burst messages after an alert",
+            timeout_enabled="Timeout users after a burst alert",
+            timeout_seconds="Timeout duration in seconds",
+        )
+        async def burst_config(
+            interaction: discord.Interaction,
+            scan_enabled: Optional[bool] = None,
+            window_seconds: Optional[app_commands.Range[int, 5, 600]] = None,
+            delete_messages: Optional[bool] = None,
+            timeout_enabled: Optional[bool] = None,
+            timeout_seconds: Optional[app_commands.Range[int, 1, 86400]] = None,
+        ):
+            if not await self.can_manage_scam_images(interaction):
+                await interaction.response.send_message("You need moderation permissions.", ephemeral=True)
+                return
+            if not interaction.guild:
+                await interaction.response.send_message("Run this in a server.", ephemeral=True)
+                return
+
+            await interaction.response.defer(ephemeral=True)
+            updates = {
+                "scam_image_burst_scan_enabled": scan_enabled,
+                "scam_image_burst_window_seconds": window_seconds,
+                "scam_image_burst_delete_messages": delete_messages,
+                "scam_image_burst_timeout_enabled": timeout_enabled,
+                "scam_image_burst_timeout_seconds": timeout_seconds,
+            }
+            changed = await self._save_image_burst_settings(interaction.guild, updates)
+            embed = await self._image_burst_settings_embed(interaction.guild, changed=changed)
+            await interaction.followup.send(embed=embed, ephemeral=True)
 
         @group.command(name="list", description="List scam image signatures")
         async def list_signatures(
@@ -414,6 +452,112 @@ class ScamImageController:
         if any(role_id and discord.utils.get(interaction.user.roles, id=role_id) for role_id in role_ids):
             return True
         return False
+
+    async def _load_image_burst_settings(self, guild: Optional[discord.Guild], *, force: bool = False):
+        if not guild:
+            return
+        guild_id = str(guild.id)
+        if not force and guild_id in self._image_burst_settings_loaded_guilds:
+            return
+        moderation_manager = self._get_moderation_manager()
+        if not moderation_manager:
+            return
+
+        self.image_burst_scan_enabled = self._coerce_bool(
+            await moderation_manager.get_moderation_setting(
+                guild_id,
+                "scam_image_burst_scan_enabled",
+                self.image_burst_scan_enabled,
+            ),
+            self.image_burst_scan_enabled,
+        )
+        self.image_burst_window_seconds = self._coerce_int(
+            await moderation_manager.get_moderation_setting(
+                guild_id,
+                "scam_image_burst_window_seconds",
+                self.image_burst_window_seconds,
+            ),
+            self.image_burst_window_seconds,
+        )
+        self.image_burst_delete_messages = self._coerce_bool(
+            await moderation_manager.get_moderation_setting(
+                guild_id,
+                "scam_image_burst_delete_messages",
+                self.image_burst_delete_messages,
+            ),
+            self.image_burst_delete_messages,
+        )
+        self.image_burst_timeout_enabled = self._coerce_bool(
+            await moderation_manager.get_moderation_setting(
+                guild_id,
+                "scam_image_burst_timeout_enabled",
+                self.image_burst_timeout_enabled,
+            ),
+            self.image_burst_timeout_enabled,
+        )
+        self.image_burst_timeout_seconds = self._coerce_int(
+            await moderation_manager.get_moderation_setting(
+                guild_id,
+                "scam_image_burst_timeout_seconds",
+                self.image_burst_timeout_seconds,
+            ),
+            self.image_burst_timeout_seconds,
+        )
+        self._image_burst_settings_loaded_guilds.add(guild_id)
+
+    async def _save_image_burst_settings(self, guild: discord.Guild, updates: dict) -> list[str]:
+        moderation_manager = self._get_moderation_manager()
+        changed = []
+        for setting_name, value in updates.items():
+            if value is None:
+                continue
+            if moderation_manager:
+                saved = await moderation_manager.set_moderation_setting(str(guild.id), setting_name, value)
+                if not saved:
+                    logger.warning("Could not save scam image burst setting %s for guild %s", setting_name, guild.id)
+                    continue
+            setattr(self, self._image_burst_setting_attribute(setting_name), value)
+            changed.append(setting_name)
+        self._image_burst_settings_loaded_guilds.discard(str(guild.id))
+        await self._load_image_burst_settings(guild, force=True)
+        return changed
+
+    async def _image_burst_settings_embed(self, guild: discord.Guild, *, changed: list[str]) -> discord.Embed:
+        await self._load_image_burst_settings(guild, force=True)
+        embed = discord.Embed(title="Repeated Image Burst Config", color=discord.Color.blurple())
+        embed.add_field(name="Scan Enabled", value=str(self.image_burst_scan_enabled), inline=True)
+        embed.add_field(name="Window", value=f"{self.image_burst_window_seconds}s", inline=True)
+        embed.add_field(name="Delete Messages", value=str(self.image_burst_delete_messages), inline=True)
+        embed.add_field(name="Timeout Enabled", value=str(self.image_burst_timeout_enabled), inline=True)
+        embed.add_field(name="Timeout Duration", value=f"{self.image_burst_timeout_seconds}s", inline=True)
+        if changed:
+            labels = [name.replace("scam_image_burst_", "").replace("_", " ") for name in changed]
+            embed.add_field(name="Updated", value=", ".join(labels), inline=False)
+        else:
+            embed.add_field(name="Updated", value="No changes; showing current config.", inline=False)
+        return embed
+
+    def _image_burst_setting_attribute(self, setting_name: str) -> str:
+        return {
+            "scam_image_burst_scan_enabled": "image_burst_scan_enabled",
+            "scam_image_burst_window_seconds": "image_burst_window_seconds",
+            "scam_image_burst_delete_messages": "image_burst_delete_messages",
+            "scam_image_burst_timeout_enabled": "image_burst_timeout_enabled",
+            "scam_image_burst_timeout_seconds": "image_burst_timeout_seconds",
+        }[setting_name]
+
+    def _coerce_bool(self, value, default: bool) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() == "true"
+        return default
+
+    def _coerce_int(self, value, default: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
 
     async def _build_image_timeline_report(
         self,
@@ -703,9 +847,11 @@ class ScamImageController:
         )
 
     async def _maybe_send_repeated_image_burst_alert(self, message: discord.Message, attachment):
+        if not message.guild:
+            return
+        await self._load_image_burst_settings(message.guild)
         if (
-            not message.guild
-            or not self.image_burst_scan_enabled
+            not self.image_burst_scan_enabled
             or not self.manager.is_supported_image(attachment.filename)
             or message.channel.id in self.image_burst_ignored_channel_ids
             or self.cross_channel_threshold <= 1

--- a/controllers/scam_image_controller.py
+++ b/controllers/scam_image_controller.py
@@ -380,7 +380,11 @@ class ScamImageController:
                 "scam_image_burst_timeout_seconds": timeout_seconds,
                 "scam_image_burst_dm_security_notice": dm_security_notice,
             }
-            changed = await self._save_image_burst_settings(interaction.guild, updates)
+            try:
+                changed = await self._save_image_burst_settings(interaction.guild, updates)
+            except RuntimeError as e:
+                await interaction.followup.send(str(e), ephemeral=True)
+                return
             embed = await self._image_burst_settings_embed(interaction.guild, changed=changed)
             await interaction.followup.send(embed=embed, ephemeral=True)
 
@@ -520,15 +524,17 @@ class ScamImageController:
 
     async def _save_image_burst_settings(self, guild: discord.Guild, updates: dict) -> list[str]:
         moderation_manager = self._get_moderation_manager()
+        has_updates = any(value is not None for value in updates.values())
+        if has_updates and not moderation_manager:
+            raise RuntimeError("Could not update repeated-image burst config: moderation settings are unavailable.")
         changed = []
         for setting_name, value in updates.items():
             if value is None:
                 continue
-            if moderation_manager:
-                saved = await moderation_manager.set_moderation_setting(str(guild.id), setting_name, value)
-                if not saved:
-                    logger.warning("Could not save scam image burst setting %s for guild %s", setting_name, guild.id)
-                    continue
+            saved = await moderation_manager.set_moderation_setting(str(guild.id), setting_name, value)
+            if not saved:
+                logger.warning("Could not save scam image burst setting %s for guild %s", setting_name, guild.id)
+                continue
             setattr(self, self._image_burst_setting_attribute(setting_name), value)
             changed.append(setting_name)
         self._image_burst_settings_loaded_guilds.discard(str(guild.id))

--- a/views/scam_image_view.py
+++ b/views/scam_image_view.py
@@ -76,6 +76,10 @@ def image_burst_alert_embed(
         channel_id = entry.get("channel_id")
         if channel_id and channel_id not in channel_ids:
             channel_ids.append(channel_id)
+    created_times = sorted(entry.get("created_at") for entry in entries if entry.get("created_at"))
+    first_seen = created_times[0] if created_times else None
+    last_seen = created_times[-1] if created_times else None
+    span_seconds = int((last_seen - first_seen).total_seconds()) if first_seen and last_seen else 0
 
     embed = discord.Embed(
         title="Repeated Image Burst Alert",
@@ -89,9 +93,21 @@ def image_burst_alert_embed(
     embed.add_field(name="User", value=f"{message.author.mention}\n`{message.author}`", inline=True)
     embed.add_field(name="Threshold", value=f"{threshold}+ channels", inline=True)
     embed.add_field(name="Match", value=match_kind, inline=True)
+    embed.add_field(name="Images", value=str(len(entries)), inline=True)
+    embed.add_field(name="Channels", value=str(len(channel_ids)), inline=True)
+    embed.add_field(name="Span", value=f"{span_seconds}s", inline=True)
+    if first_seen and last_seen:
+        embed.add_field(
+            name="Timing",
+            value=(
+                f"First: <t:{int(first_seen.timestamp())}:T>\n"
+                f"Latest: <t:{int(last_seen.timestamp())}:T>"
+            ),
+            inline=True,
+        )
     if actions:
         embed.add_field(name="Actions", value="\n".join(actions), inline=False)
-    embed.add_field(name="Channels", value="\n".join(f"<#{channel_id}>" for channel_id in channel_ids[:10]), inline=False)
+    embed.add_field(name="Affected Channels", value="\n".join(f"<#{channel_id}>" for channel_id in channel_ids[:10]), inline=False)
 
     recent = []
     for entry in entries[:5]:


### PR DESCRIPTION
Summary
- add /scamimage burst_config for mod-only runtime control of repeated-image burst settings
- allow mods to view/update scan_enabled, window_seconds, delete_messages, timeout_enabled, and timeout_seconds
- persist overrides through the existing moderation_settings collection
- load cached guild burst settings before status, timeline, and live repeated-image burst handling

Safety notes
- uses the existing scamimage permission gate
- no direct messages to mods/admins
- no new collection or schema migration; settings are additive moderation_settings rows
- based on current main after PR #25 was merged

Verification
- python tests\\test_scam_image_manager_smoke.py
- python -m compileall -q bot.py config.py controllers models views tests tools
- git diff --check --cached