### PR TITLE
Add optional sandbox mode for managed bot intake installs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+DISCORD_TOKEN=
+GUILD_ID=
+COMMAND_PREFIX=R!
+MONGO_URI=
+
+# Enable this when Ino is installed through a restricted bot-intake sandbox.
+INO_SANDBOX_MODE=true
+
+# Required comma-separated channel IDs where Ino may answer commands in sandbox mode.
+# Use the bot-intake approved text channel IDs.
+INO_SANDBOX_CHANNEL_IDS=123456789012345678
+
+# Required only outside sandbox mode.
+BANNED_ROLE_ID=
+RESTRICTED_ROLE_ID=
+
+# Optional feature providers.
+GEMINI_API_KEY=
+OPENAI_KEY=
+GOOGLE_NL_API_KEY=
+GOOGLE_TRANSLATE_API_KEY=
+YOUTUBE_API_KEY=
+TWITCH_CLIENT=
+TWITCH_SECRET=
+SERIKA_ART_KEY=
+
+# Keep destructive moderation features off for sandbox/persona installs.
+SCAM_IMAGE_DETECTION_ENABLED=false
+SCAM_IMAGE_DELETE_MATCHES=false
+SCAM_IMAGE_BURST_DELETE_MESSAGES=false
+SCAM_IMAGE_BURST_TIMEOUT_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ RESTRICTED_ROLE_ID=your_restricted_role_id
 MONGO_URI=mongodb+srv://user:pass@cluster.mongodb.net/database
 ```
 
+For restricted community/persona installs through a bot-intake sandbox, enable:
+
+```env
+INO_SANDBOX_MODE=true
+INO_SANDBOX_CHANNEL_IDS=bot_chat_channel_id,other_approved_text_channel_id
+```
+
+Sandbox mode keeps Ino on the existing Discord permission rails: only public commands are allowed, command/event handling is limited to the approved sandbox channels, global slash-command sync is skipped, member lifecycle handlers are not registered, and privileged moderation/announcement automations are disabled.
+When sandbox mode is enabled, `BANNED_ROLE_ID` and `RESTRICTED_ROLE_ID` are no longer required.
+
 ### Optional Environment Variables
 
 ```env
@@ -198,11 +208,16 @@ Enable these permissions when inviting the bot:
 - ✅ Read Message History
 - ✅ Manage Messages
 
+For sandbox/persona installs, do not grant `Manage Roles`, `Manage Messages`, `Moderate Members`, or `Administrator`.
+Use the bot-intake `default_bot` or `voice_chatbot` preset and enable slash commands only when reviewers will scope the app in Discord Integrations.
+
 ### Required Bot Intents
 
 Enable these intents in the Discord Developer Portal:
 - ✅ Server Members Intent
 - ✅ Message Content Intent
+
+Sandbox/persona installs only require Message Content Intent.
 
 ---
 
@@ -409,7 +424,7 @@ Structured JSON logging with:
 3. **Verify intents** - Enable required intents in Developer Portal
 4. **Re-invite bot** with proper scopes:
    ```
-   https://discord.com/api/oauth2/authorize?client_id=YOUR_BOT_ID&permissions=8&scope=bot%20applications.commands
+   https://discord.com/api/oauth2/authorize?client_id=YOUR_BOT_ID&permissions=352670538909696&scope=bot%20applications.commands
    ```
 
 ### MongoDB Connection Issues

--- a/bot.py
+++ b/bot.py
@@ -14,9 +14,6 @@ if TYPE_CHECKING:
     from models.youtube_monitor import YouTubeMonitor
     from models.twitch_monitor import TwitchMonitor
 
-# Always import RandomAnnouncer for runtime use
-from models.random_announcer import RandomAnnouncer
-
 # Set up logging
 logging.basicConfig(
     level=logging.INFO,
@@ -31,7 +28,7 @@ class RikoBot(commands.Bot):
         # Define intents
         intents = discord.Intents.default()
         intents.message_content = True
-        intents.members = True
+        intents.members = not Config.SANDBOX_MODE
         intents.reactions = True
         intents.guilds = True
         
@@ -44,13 +41,18 @@ class RikoBot(commands.Bot):
             activity=discord.Activity(type=discord.ActivityType.watching, name="Discord members"),
             status=discord.Status.online
         )
+
+        if Config.SANDBOX_MODE:
+            self.tree.interaction_check = self._tree_interaction_check
         
         # Add a check to restrict the bot to the Rayen server only
         @self.check
         async def globally_block_dms_and_other_guilds(ctx):
             """Block all commands in DMs and guilds other than the configured one"""
-            # Allow in the configured guild
+            # Allow in the configured guild unless sandbox mode adds tighter checks.
             if ctx.guild and ctx.guild.id == Config.GUILD_ID:
+                if Config.SANDBOX_MODE:
+                    return await self._allow_sandbox_command_context(ctx)
                 return True
             
             # Block in DMs
@@ -97,43 +99,47 @@ class RikoBot(commands.Bot):
                 logger.error(f"❌ Failed to initialize fallback leaderboard manager: {e2}")
                 self.leaderboard_manager = None
         
-        # Initialize YouTube monitor
-        try:
-            from models.youtube_monitor import YouTubeMonitor
-            from models.mongo_leaderboard_manager import MongoLeaderboardManager
-            # Only pass MongoDB manager if it's the right type
-            if isinstance(self.leaderboard_manager, MongoLeaderboardManager):
-                self.youtube_monitor = YouTubeMonitor(self.leaderboard_manager)
-            else:
-                self.youtube_monitor = YouTubeMonitor(None)
-            # Set bot reference for Discord operations
-            self.youtube_monitor.bot = self
-            logger.info("✅ YouTube monitor initialized successfully")
-        except Exception as e:
-            logger.error(f"❌ Failed to initialize YouTube monitor: {e}")
-            self.youtube_monitor = None
-        
-        # Initialize Twitch monitor
-        try:
-            from models.twitch_monitor import TwitchMonitor
-            from models.mongo_leaderboard_manager import MongoLeaderboardManager
-            if isinstance(self.leaderboard_manager, MongoLeaderboardManager):
-                self.twitch_monitor = TwitchMonitor(self.leaderboard_manager)
-            else:
-                self.twitch_monitor = TwitchMonitor(None)
-            self.twitch_monitor.bot = self
-            logger.info("✅ Twitch monitor initialized successfully")
-        except Exception as e:
-            logger.error(f"❌ Failed to initialize Twitch monitor: {e}")
-            self.twitch_monitor = None
-        
-        # Initialize Random Announcer (TEMPORARY FOR RESEARCH)
-        try:
-            self.random_announcer = RandomAnnouncer(self, self.leaderboard_manager)
-            logger.info("✅ Random announcer initialized successfully")
-        except Exception as e:
-            logger.error(f"❌ Failed to initialize random announcer: {e}")
-            self.random_announcer = None
+        if Config.SANDBOX_MODE:
+            logger.info("🛡️ Ino sandbox mode enabled: privileged automations and member lifecycle actions are disabled")
+        else:
+            # Initialize YouTube monitor
+            try:
+                from models.youtube_monitor import YouTubeMonitor
+                from models.mongo_leaderboard_manager import MongoLeaderboardManager
+                # Only pass MongoDB manager if it's the right type
+                if isinstance(self.leaderboard_manager, MongoLeaderboardManager):
+                    self.youtube_monitor = YouTubeMonitor(self.leaderboard_manager)
+                else:
+                    self.youtube_monitor = YouTubeMonitor(None)
+                # Set bot reference for Discord operations
+                self.youtube_monitor.bot = self
+                logger.info("✅ YouTube monitor initialized successfully")
+            except Exception as e:
+                logger.error(f"❌ Failed to initialize YouTube monitor: {e}")
+                self.youtube_monitor = None
+
+            # Initialize Twitch monitor
+            try:
+                from models.twitch_monitor import TwitchMonitor
+                from models.mongo_leaderboard_manager import MongoLeaderboardManager
+                if isinstance(self.leaderboard_manager, MongoLeaderboardManager):
+                    self.twitch_monitor = TwitchMonitor(self.leaderboard_manager)
+                else:
+                    self.twitch_monitor = TwitchMonitor(None)
+                self.twitch_monitor.bot = self
+                logger.info("✅ Twitch monitor initialized successfully")
+            except Exception as e:
+                logger.error(f"❌ Failed to initialize Twitch monitor: {e}")
+                self.twitch_monitor = None
+
+            # Initialize Random Announcer (TEMPORARY FOR RESEARCH)
+            try:
+                from models.random_announcer import RandomAnnouncer
+                self.random_announcer = RandomAnnouncer(self, self.leaderboard_manager)
+                logger.info("✅ Random announcer initialized successfully")
+            except Exception as e:
+                logger.error(f"❌ Failed to initialize random announcer: {e}")
+                self.random_announcer = None
         
         # Initialize controllers
         from controllers.events import EventsController
@@ -144,7 +150,7 @@ class RikoBot(commands.Bot):
         self.commands_controller = CommandsController(self)
         self.scheduler_controller = SchedulerController(self)
 
-        if self.scam_image_manager:
+        if self.scam_image_manager and not Config.SANDBOX_MODE:
             try:
                 from controllers.scam_image_controller import ScamImageController
                 self.scam_image_controller = ScamImageController(self, self.scam_image_manager)
@@ -154,15 +160,16 @@ class RikoBot(commands.Bot):
                 self.scam_image_controller = None
         
         # Initialize moderation view manager
-        try:
-            from views.moderation_view import ModerationViewManager
-            self.moderation_view_manager = ModerationViewManager(self)
-            # Setup persistent views
-            self.moderation_view_manager.setup_persistent_views()
-            logger.info("✅ Moderation view manager initialized successfully")
-        except Exception as e:
-            logger.error(f"❌ Failed to initialize moderation view manager: {e}")
-            self.moderation_view_manager = None
+        if not Config.SANDBOX_MODE:
+            try:
+                from views.moderation_view import ModerationViewManager
+                self.moderation_view_manager = ModerationViewManager(self)
+                # Setup persistent views
+                self.moderation_view_manager.setup_persistent_views()
+                logger.info("✅ Moderation view manager initialized successfully")
+            except Exception as e:
+                logger.error(f"❌ Failed to initialize moderation view manager: {e}")
+                self.moderation_view_manager = None
         
         # Initialize art challenge manager and view manager
         self.art_challenge_manager = None
@@ -198,13 +205,14 @@ class RikoBot(commands.Bot):
             self.custom_roles_manager = None
 
         # Initialize art random events manager
-        try:
-            from models.art_random_events_manager import ArtRandomEventsManager
-            self.art_random_events_manager = ArtRandomEventsManager()
-            logger.info("✅ Art random events manager initialized successfully")
-        except Exception as e:
-            logger.error(f"❌ Failed to initialize art random events manager: {e}")
-            self.art_random_events_manager = None
+        if not Config.SANDBOX_MODE:
+            try:
+                from models.art_random_events_manager import ArtRandomEventsManager
+                self.art_random_events_manager = ArtRandomEventsManager()
+                logger.info("✅ Art random events manager initialized successfully")
+            except Exception as e:
+                logger.error(f"❌ Failed to initialize art random events manager: {e}")
+                self.art_random_events_manager = None
     
     async def setup_hook(self):
         """Initial setup when bot is starting"""
@@ -223,6 +231,48 @@ class RikoBot(commands.Bot):
             self.events_controller.initialize_quest_manager()
         
         logger.info("Bot setup completed")
+
+    async def _tree_interaction_check(self, interaction: discord.Interaction) -> bool:
+        return await self._allow_sandbox_interaction(interaction, notify=True)
+
+    async def _allow_sandbox_interaction(self, interaction: discord.Interaction, notify: bool = False) -> bool:
+        if not Config.SANDBOX_MODE:
+            return True
+
+        if not interaction.guild or interaction.guild.id != Config.GUILD_ID:
+            if notify and not interaction.response.is_done():
+                await interaction.response.send_message(
+                    "This bot is only available in the approved server.",
+                    ephemeral=True
+                )
+            return False
+
+        channel_id = getattr(getattr(interaction, "channel", None), "id", None)
+        if not Config.is_sandbox_channel_allowed(channel_id):
+            if notify and not interaction.response.is_done():
+                await interaction.response.send_message(
+                    "This bot is only available in the approved sandbox channels.",
+                    ephemeral=True
+                )
+            return False
+
+        return True
+
+    async def _allow_sandbox_command_context(self, ctx) -> bool:
+        channel_id = getattr(getattr(ctx, "channel", None), "id", None)
+        if not Config.is_sandbox_channel_allowed(channel_id):
+            await ctx.send("This bot is only available in the approved sandbox channels.")
+            return False
+
+        from controllers.security import CommandSecurity, SecurityLevel
+
+        command_name = getattr(getattr(ctx, "command", None), "name", None)
+        required_level = CommandSecurity.get_command_security_level(command_name or "")
+        if required_level != SecurityLevel.PUBLIC:
+            await ctx.send("Sandbox mode only allows public persona/community commands.")
+            return False
+
+        return True
     
     async def on_ready(self):
         """Bot is ready and connected"""
@@ -254,9 +304,12 @@ class RikoBot(commands.Bot):
                 for cmd in synced_guild:
                     logger.info(f"   - /{cmd.name}: {cmd.description}")
             
-            # Also sync globally (takes up to 1 hour to propagate)
-            synced_global = await self.tree.sync()
-            logger.info(f"✅ Synced {len(synced_global)} commands globally")
+            if Config.SANDBOX_MODE:
+                logger.info("🛡️ Sandbox mode enabled; skipping global command sync")
+            else:
+                # Also sync globally (takes up to 1 hour to propagate)
+                synced_global = await self.tree.sync()
+                logger.info(f"✅ Synced {len(synced_global)} commands globally")
             
         except Exception as e:
             logger.error(f"❌ Failed to sync commands: {e}")
@@ -293,17 +346,20 @@ class RikoBot(commands.Bot):
             logger.error(f"❌ Failed to register challenge mode views: {e}")
         
         # Start scheduler tasks for best image posting
-        if self.scheduler_controller:
+        if self.scheduler_controller and not Config.SANDBOX_MODE:
             self.scheduler_controller.start_tasks()
             logger.info("Started scheduled tasks for best image posting")
             logger.info("Best images will be posted back to their original channels")
         
-        # Check and award achievements for all users on startup
-        await self.check_all_achievements_on_startup()
-        
-        # Automatically scan and store all historical images
-        await self.scan_historical_images()
-        
+        if Config.SANDBOX_MODE:
+            logger.info("🛡️ Sandbox mode enabled; skipping startup achievement sweep and historical image scan")
+        else:
+            # Check and award achievements for all users on startup
+            await self.check_all_achievements_on_startup()
+
+            # Automatically scan and store all historical images
+            await self.scan_historical_images()
+
         # Start status cycling (only if not already running)
         if not self.cycle_status.is_running():
             self.cycle_status.start()
@@ -314,6 +370,9 @@ class RikoBot(commands.Bot):
     async def on_interaction(self, interaction: discord.Interaction):
         """Handle interactions including moderation buttons"""
         try:
+            if not await self._allow_sandbox_interaction(interaction, notify=True):
+                return
+
             # Handle moderation button interactions first (for validation only)
             if (interaction.type == discord.InteractionType.component 
                 and self.moderation_view_manager):

--- a/config.py
+++ b/config.py
@@ -5,11 +5,20 @@ from typing import Optional, List
 # Load environment variables
 load_dotenv()
 
-def get_int_env(key: str, default: Optional[int] = None) -> int:
+MISSING = object()
+
+def get_bool_env(key: str, default: bool = False) -> bool:
+    """Get a boolean from environment variables."""
+    value = os.getenv(key)
+    if value is None or value == "":
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+def get_int_env(key: str, default=MISSING) -> Optional[int]:
     """Get an integer from environment variables with proper error handling"""
     value = os.getenv(key)
     if value is None:
-        if default is not None:
+        if default is not MISSING:
             return default
         raise ValueError(f"Environment variable {key} is required but not set")
     try:
@@ -41,9 +50,11 @@ class Config:
     # Command prefix for text commands
     COMMAND_PREFIX = os.getenv('COMMAND_PREFIX', 'R!')
     TOKEN = os.getenv('DISCORD_TOKEN')
+    SANDBOX_MODE = get_bool_env('INO_SANDBOX_MODE', False)
+    SANDBOX_CHANNEL_IDS = get_int_list_env('INO_SANDBOX_CHANNEL_IDS', [])
     GUILD_ID = get_int_env('GUILD_ID')
-    BANNED_ROLE_ID = get_int_env('BANNED_ROLE_ID')
-    RESTRICTED_ROLE_ID = get_int_env('RESTRICTED_ROLE_ID')
+    BANNED_ROLE_ID = get_int_env('BANNED_ROLE_ID', None if SANDBOX_MODE else MISSING)
+    RESTRICTED_ROLE_ID = get_int_env('RESTRICTED_ROLE_ID', None if SANDBOX_MODE else MISSING)
     MONGO_URI = os.getenv('MONGO_URI')
     GEMINI_API_KEY = os.getenv('GEMINI_API_KEY')  # For YouTube video announcements
     YOUTUBE_API_KEY = os.getenv('YOUTUBE_API_KEY')  # For YouTube Data API
@@ -81,7 +92,7 @@ class Config:
     
     # NSFWBAN system role IDs
     NSFWBAN_MODERATOR_ROLE_ID = 1372477845997359244  # Role that can use nsfwban commands
-    NSFWBAN_BANNED_ROLE_ID = get_int_env('BANNED_ROLE_ID')  # Role given to NSFWBAN'd users (same as BANNED_ROLE_ID)
+    NSFWBAN_BANNED_ROLE_ID = get_int_env('BANNED_ROLE_ID', None if SANDBOX_MODE else MISSING)  # Role given to NSFWBAN'd users (same as BANNED_ROLE_ID)
     
     # Patreon system
     PATREON_ROLE_ID = get_int_env('PATREON_ROLE_ID', None)  # "Riko's Agent" role for Patreon supporters (1.5x quest points)
@@ -253,10 +264,14 @@ class Config:
         required_vars = [
             ('DISCORD_TOKEN', cls.TOKEN),
             ('GUILD_ID', cls.GUILD_ID),
-            ('BANNED_ROLE_ID', cls.BANNED_ROLE_ID),
-            ('RESTRICTED_ROLE_ID', cls.RESTRICTED_ROLE_ID),
             ('MONGO_URI', cls.MONGO_URI)
         ]
+
+        if not cls.SANDBOX_MODE:
+            required_vars.extend([
+                ('BANNED_ROLE_ID', cls.BANNED_ROLE_ID),
+                ('RESTRICTED_ROLE_ID', cls.RESTRICTED_ROLE_ID)
+            ])
         
         # Optional but recommended vars
         optional_vars = [
@@ -273,8 +288,18 @@ class Config:
         
         if missing_vars:
             raise ValueError(f"Missing required environment variables: {', '.join(missing_vars)}")
+
+        if cls.SANDBOX_MODE and not cls.SANDBOX_CHANNEL_IDS:
+            raise ValueError("INO_SANDBOX_CHANNEL_IDS is required when INO_SANDBOX_MODE is enabled")
         
         if missing_optional:
             import logging
             logger = logging.getLogger(__name__)
             logger.warning(f"Missing optional environment variables (some features may not work): {', '.join(missing_optional)}")
+
+    @classmethod
+    def is_sandbox_channel_allowed(cls, channel_id: Optional[int]) -> bool:
+        """Return whether a channel is inside the sandbox allowlist."""
+        if not cls.SANDBOX_MODE:
+            return True
+        return channel_id in cls.SANDBOX_CHANNEL_IDS

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ def get_bool_env(key: str, default: bool = False) -> bool:
 def get_int_env(key: str, default=MISSING) -> Optional[int]:
     """Get an integer from environment variables with proper error handling"""
     value = os.getenv(key)
-    if value is None:
+    if value is None or value.strip() == "":
         if default is not MISSING:
             return default
         raise ValueError(f"Environment variable {key} is required but not set")

--- a/controllers/events.py
+++ b/controllers/events.py
@@ -572,6 +572,22 @@ class EventsController:
     
     def register_events(self):
         """Register all Discord events"""
+        if Config.SANDBOX_MODE:
+            @self.bot.event
+            async def on_message(message: discord.Message):
+                await self._handle_message(message)
+
+            @self.bot.event
+            async def on_command_error(ctx: commands.Context, error: commands.CommandError):
+                await self._handle_command_error(ctx, error)
+
+            @self.bot.event
+            async def on_command(ctx: commands.Context):
+                channel_name = ctx.channel.name if hasattr(ctx.channel, 'name') else 'DM'
+                logger.info(f"Command '{ctx.command.name}' invoked by {ctx.author.display_name} in #{channel_name}")
+
+            logger.info("🛡️ Sandbox mode enabled; registered message and command events only")
+            return
         
         @self.bot.event
         async def on_member_join(member: discord.Member):
@@ -984,6 +1000,20 @@ class EventsController:
     
     async def _handle_message(self, message: discord.Message):
         """Handle new messages for image reactions and member join stickers"""
+        if (
+            Config.SANDBOX_MODE
+            and message.guild
+            and message.guild.id == Config.GUILD_ID
+            and not Config.is_sandbox_channel_allowed(message.channel.id)
+        ):
+            return
+
+        if Config.SANDBOX_MODE:
+            if message.author.bot:
+                return
+            await self.bot.process_commands(message)
+            return
+
         # Check for member join system messages FIRST (before ignoring bot messages)
         if message.guild and message.guild.id == Config.GUILD_ID:
             await self._handle_member_join_message(message)
@@ -1008,7 +1038,7 @@ class EventsController:
         
         # IMPORTANT: Process commands first for text commands to work
         await self.bot.process_commands(message)
-        
+
         # Only process messages from the configured guild
         if not message.guild or message.guild.id != Config.GUILD_ID:
             return

--- a/controllers/security.py
+++ b/controllers/security.py
@@ -67,7 +67,15 @@ class CommandSecurity:
         """
         user = ctx.author
         
-        # Bot owners can always use any command
+        if Config.SANDBOX_MODE:
+            channel_id = getattr(getattr(ctx, "channel", None), "id", None)
+            if not Config.is_sandbox_channel_allowed(channel_id):
+                return False, "This bot is only available in the approved sandbox channels."
+
+            if required_level != SecurityLevel.PUBLIC:
+                return False, "Sandbox mode only allows public persona/community commands."
+
+        # Bot owners can always use any command outside sandbox mode
         if await ctx.bot.is_owner(user):
             return True, ""
         

--- a/sync_commands.py
+++ b/sync_commands.py
@@ -16,7 +16,7 @@ async def sync_commands():
     try:
         # Create bot instance
         intents = discord.Intents.default()
-        intents.members = True
+        intents.members = not Config.SANDBOX_MODE
         intents.message_content = True
         
         bot = commands.Bot(command_prefix='R!', intents=intents)
@@ -56,8 +56,8 @@ async def sync_commands():
             
             # Generate invite URL with proper permissions and applications.commands scope
             bot_id = bot.user.id
-            # Updated URL with applications.commands scope
-            invite_url = f"https://discord.com/api/oauth2/authorize?client_id={bot_id}&permissions=268437568&scope=bot%20applications.commands"
+            permissions = 352670538909696 if Config.SANDBOX_MODE else 268437568
+            invite_url = f"https://discord.com/api/oauth2/authorize?client_id={bot_id}&permissions={permissions}&scope=bot%20applications.commands"
             
             print(f"\n🔗 IMPORTANT: Use this invite URL to add applications.commands scope:")
             print(f"{invite_url}")
@@ -83,13 +83,17 @@ async def sync_commands():
                 for cmd in synced_guild:
                     print(f"   - /{cmd.name}")
                 
-                # Try global sync
-                synced_global = await bot.tree.sync()
-                print(f"✅ Global sync: {len(synced_global)} commands")
-                for cmd in synced_global:
-                    print(f"   - /{cmd.name}")
-                
-                if len(synced_global) == 0:
+                if Config.SANDBOX_MODE:
+                    synced_global = []
+                    print("🛡️ Sandbox mode enabled; skipped global command sync")
+                else:
+                    # Try global sync
+                    synced_global = await bot.tree.sync()
+                    print(f"✅ Global sync: {len(synced_global)} commands")
+                    for cmd in synced_global:
+                        print(f"   - /{cmd.name}")
+
+                if not Config.SANDBOX_MODE and len(synced_global) == 0:
                     print("\n❌ NO COMMANDS SYNCED!")
                     print("❌ This is because the bot lacks 'applications.commands' scope")
                     print("❌ Please use the invite URL above to re-add the bot")

--- a/tests/test_bot_sandbox_interactions.py
+++ b/tests/test_bot_sandbox_interactions.py
@@ -1,0 +1,100 @@
+import asyncio
+import os
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ["DISCORD_TOKEN"] = "dummy"
+os.environ["GUILD_ID"] = "123456789012345678"
+os.environ["MONGO_URI"] = "mongodb://example.invalid/ino"
+os.environ["INO_SANDBOX_MODE"] = "true"
+os.environ["INO_SANDBOX_CHANNEL_IDS"] = "111111111111111111,222222222222222222"
+os.environ.pop("BANNED_ROLE_ID", None)
+os.environ.pop("RESTRICTED_ROLE_ID", None)
+
+from bot import RikoBot
+from config import Config
+
+
+class FakeCommandContext:
+    def __init__(self, command_name, channel_id):
+        self.command = SimpleNamespace(name=command_name) if command_name else None
+        self.channel = SimpleNamespace(id=channel_id) if channel_id is not None else None
+        self.sent = []
+
+    async def send(self, content):
+        self.sent.append(content)
+
+
+class FakeResponse:
+    def __init__(self):
+        self.sent = []
+        self._done = False
+
+    def is_done(self):
+        return self._done
+
+    async def send_message(self, content, ephemeral=False):
+        self.sent.append((content, ephemeral))
+        self._done = True
+
+
+def fake_interaction(guild_id, channel_id):
+    guild = SimpleNamespace(id=guild_id) if guild_id is not None else None
+    channel = SimpleNamespace(id=channel_id) if channel_id is not None else None
+    return SimpleNamespace(guild=guild, channel=channel, response=FakeResponse())
+
+
+async def run_checks():
+    bot = RikoBot.__new__(RikoBot)
+
+    allowed = fake_interaction(Config.GUILD_ID, 111111111111111111)
+    assert await RikoBot._allow_sandbox_interaction(bot, allowed, notify=True) is True
+    assert allowed.response.sent == []
+
+    outside_channel = fake_interaction(Config.GUILD_ID, 333333333333333333)
+    assert await RikoBot._allow_sandbox_interaction(bot, outside_channel, notify=True) is False
+    assert outside_channel.response.sent == [
+        ("This bot is only available in the approved sandbox channels.", True)
+    ]
+
+    wrong_guild = fake_interaction(999999999999999999, 111111111111111111)
+    assert await RikoBot._tree_interaction_check(bot, wrong_guild) is False
+    assert wrong_guild.response.sent == [
+        ("This bot is only available in the approved server.", True)
+    ]
+
+    dm = fake_interaction(None, None)
+    assert await RikoBot._allow_sandbox_interaction(bot, dm, notify=True) is False
+    assert dm.response.sent == [
+        ("This bot is only available in the approved server.", True)
+    ]
+
+    public_context = FakeCommandContext("leaderboard", 111111111111111111)
+    assert await RikoBot._allow_sandbox_command_context(bot, public_context) is True
+    assert public_context.sent == []
+
+    admin_context = FakeCommandContext("warn", 111111111111111111)
+    assert await RikoBot._allow_sandbox_command_context(bot, admin_context) is False
+    assert admin_context.sent == ["Sandbox mode only allows public persona/community commands."]
+
+    unknown_context = FakeCommandContext("totally_unknown", 111111111111111111)
+    assert await RikoBot._allow_sandbox_command_context(bot, unknown_context) is False
+    assert unknown_context.sent == ["Sandbox mode only allows public persona/community commands."]
+
+    wrong_channel_context = FakeCommandContext("leaderboard", 333333333333333333)
+    assert await RikoBot._allow_sandbox_command_context(bot, wrong_channel_context) is False
+    assert wrong_channel_context.sent == [
+        "This bot is only available in the approved sandbox channels."
+    ]
+
+
+def main():
+    asyncio.run(run_checks())
+    print("bot sandbox interaction test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sandbox_mode.py
+++ b/tests/test_sandbox_mode.py
@@ -11,10 +11,11 @@ os.environ["GUILD_ID"] = "123456789012345678"
 os.environ["MONGO_URI"] = "mongodb://example.invalid/ino"
 os.environ["INO_SANDBOX_MODE"] = "true"
 os.environ["INO_SANDBOX_CHANNEL_IDS"] = "111111111111111111,222222222222222222"
-os.environ.pop("BANNED_ROLE_ID", None)
-os.environ.pop("RESTRICTED_ROLE_ID", None)
+os.environ["BANNED_ROLE_ID"] = ""
+os.environ["RESTRICTED_ROLE_ID"] = ""
 
 from config import Config
+from config import get_int_env
 from controllers.security import CommandSecurity, SecurityLevel
 
 
@@ -34,6 +35,8 @@ def main():
     assert Config.SANDBOX_MODE is True
     assert Config.BANNED_ROLE_ID is None
     assert Config.RESTRICTED_ROLE_ID is None
+    os.environ["OPTIONAL_EMPTY_ROLE_ID"] = "   "
+    assert get_int_env("OPTIONAL_EMPTY_ROLE_ID", None) is None
     assert Config.is_sandbox_channel_allowed(111111111111111111) is True
     assert Config.is_sandbox_channel_allowed(333333333333333333) is False
 

--- a/tests/test_sandbox_mode.py
+++ b/tests/test_sandbox_mode.py
@@ -1,0 +1,74 @@
+import asyncio
+import os
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ["DISCORD_TOKEN"] = "dummy"
+os.environ["GUILD_ID"] = "123456789012345678"
+os.environ["MONGO_URI"] = "mongodb://example.invalid/ino"
+os.environ["INO_SANDBOX_MODE"] = "true"
+os.environ["INO_SANDBOX_CHANNEL_IDS"] = "111111111111111111,222222222222222222"
+os.environ.pop("BANNED_ROLE_ID", None)
+os.environ.pop("RESTRICTED_ROLE_ID", None)
+
+from config import Config
+from controllers.security import CommandSecurity, SecurityLevel
+
+
+class FakeBot:
+    async def is_owner(self, user):
+        return True
+
+
+def fake_context(channel_id):
+    permissions = SimpleNamespace(administrator=True, manage_guild=True)
+    author = SimpleNamespace(guild_permissions=permissions, roles=[])
+    channel = SimpleNamespace(id=channel_id)
+    return SimpleNamespace(author=author, channel=channel, guild=object(), bot=FakeBot())
+
+
+def main():
+    assert Config.SANDBOX_MODE is True
+    assert Config.BANNED_ROLE_ID is None
+    assert Config.RESTRICTED_ROLE_ID is None
+    assert Config.is_sandbox_channel_allowed(111111111111111111) is True
+    assert Config.is_sandbox_channel_allowed(333333333333333333) is False
+
+    original_channels = Config.SANDBOX_CHANNEL_IDS
+    try:
+        Config.SANDBOX_CHANNEL_IDS = []
+        assert Config.is_sandbox_channel_allowed(111111111111111111) is False
+        try:
+            Config.validate()
+        except ValueError as error:
+            assert "INO_SANDBOX_CHANNEL_IDS" in str(error)
+        else:
+            raise AssertionError("sandbox mode must require INO_SANDBOX_CHANNEL_IDS")
+    finally:
+        Config.SANDBOX_CHANNEL_IDS = original_channels
+
+    public_allowed, _ = asyncio.run(
+        CommandSecurity.check_permissions(fake_context(111111111111111111), SecurityLevel.PUBLIC)
+    )
+    assert public_allowed is True
+
+    admin_allowed, admin_error = asyncio.run(
+        CommandSecurity.check_permissions(fake_context(111111111111111111), SecurityLevel.ADMIN)
+    )
+    assert admin_allowed is False
+    assert "Sandbox mode" in admin_error
+
+    outside_allowed, outside_error = asyncio.run(
+        CommandSecurity.check_permissions(fake_context(333333333333333333), SecurityLevel.PUBLIC)
+    )
+    assert outside_allowed is False
+    assert "sandbox channels" in outside_error
+
+    print("sandbox mode test passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an optional sandbox mode for servers that onboard community/persona bots through a fixed-permission, moderator-approved bot intake flow.

This does not change normal Ino behavior by default. Existing installs continue to use the current member intent, moderation handlers, scheduled jobs, global command sync, and role requirements unless `INO_SANDBOX_MODE=true` is configured.

## Why

Some community servers want to let people submit persona/chat bots by public client ID, while moderators control the actual Discord invite permissions and where the bot can operate. In that model, the submitter does not provide an invite URL or permission integer. Reviewers generate the invite from server-owned presets, install the bot manually, and place it behind a sandbox role/channel policy.

For that flow, Ino needs a low-privilege mode that cooperates with the server-side sandbox instead of assuming it has moderation or member-management permissions.

## What Changes

- Adds `INO_SANDBOX_MODE` and `INO_SANDBOX_CHANNEL_IDS` configuration.
- Requires `INO_SANDBOX_CHANNEL_IDS` when sandbox mode is enabled, so sandbox mode fails closed if no approved channels are configured.
- Makes `BANNED_ROLE_ID` and `RESTRICTED_ROLE_ID` optional only in sandbox mode.
- Disables the members intent in sandbox mode.
- Skips privileged/background systems in sandbox mode, including moderation views, scam image controller registration, YouTube/Twitch monitors, random announcer, scheduler startup, startup achievement sweep, historical image scan, and member lifecycle event handlers.
- Adds command guards so sandbox mode only allows public persona/community commands in approved channels.
- Adds an app-command interaction guard so slash commands/components are rejected outside the configured sandbox channels.
- Skips global slash-command sync in sandbox mode while preserving guild sync.
- Updates docs and `.env.example` for managed sandbox installs.
- Adds lightweight sandbox tests.

## Intended Server Flow

A server using this mode would typically do something like:

1. A user submits only the bot's public Discord client ID, bot name, and purpose.
2. A moderator reviews the request.
3. The server's intake tooling generates the OAuth invite using a fixed permission preset.
4. The moderator manually installs the bot.
5. The bot receives the server's sandbox bot role.
6. That role is denied outside approved bot channels and allowed only inside the bot text/voice areas.
7. If slash commands are installed, reviewers can additionally scope the app under Discord Integrations.
8. Ino runs with `INO_SANDBOX_MODE=true` and `INO_SANDBOX_CHANNEL_IDS` set to those approved bot channels.

This keeps permission decisions on the server/moderator side, while this PR makes Ino avoid privileged actions it cannot or should not perform in that low-trust install mode.

## Validation

Ran:

```powershell
py -3 tests\test_bot_sandbox_interactions.py
py -3 tests\test_sandbox_mode.py
python tests\test_scam_image_manager_smoke.py
py -3 -m compileall -q bot.py config.py controllers models views sync_commands.py tests
git diff --check
```

Also verified that sandbox import works with dummy required env values and no banned/restricted role IDs.